### PR TITLE
Schema compliance edits

### DIFF
--- a/Makefile.paths.original
+++ b/Makefile.paths.original
@@ -29,21 +29,10 @@
 # PRJ = /Users/greenj/precalc1-MHCC
 PRJ =
 
-# MathBook XML distribution root
+# PreTeXt distribution root
 # Example:
-# MB = /Users/greenj/mathbook
-MB =
-
-# These are executables to helper applications
-# Provide as much of a path as is needed
-
-# LaTeX engine, executable
-# xelatex is preferable, but pdflatex is another option
-ENGINE = xelatex
-
-# Text file viewer (eg, DTD errors)
-# "more" or "less" are likely system utilities
-PAGER = more
+# PTX = /Users/greenj/mathbook
+PTX =
 
 # HTML viewer  (eg "open -a firefox", "open -a safari", on Mac)
 HTMLVIEWER = firefox

--- a/publication/publication.xml
+++ b/publication/publication.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+## ********************************************************************* ##
+## Copyright 2016                                                        ##
+## Jack Green, Nick Chura                                                ##
+##                                                                       ##
+## This file is part of the Mount Hood Community College                 ##
+## Precalculus Project                                                   ##
+##                                                                       ##
+## ********************************************************************* ##
+-->
+
+<publication>
+
+    <!-- Relative path, relative to "main" source file -->
+    <source webwork-problems="../output/webwork-representations/webwork-representations.ptx"/>
+
+    <!-- HTML-Specific Options -->
+    <html>
+        <calculator model="geogebra-graphing"/>
+        <index-page ref="frontmatter"/>
+        <video privacy="yes"/>
+    </html>
+</publication>

--- a/src/activity-average-rate-of-change.xml
+++ b/src/activity-average-rate-of-change.xml
@@ -54,13 +54,11 @@
 
     <exercise>
       <webwork>
-          <setup>
 
             <pg-code>
                 $train = RadioButtons(["Blue Train (dotted line)","Red Train (dashed line)","Green Train (solid line)"],0);
                 $slope = RadioButtons(["mope","dope","slope","scope"],2);
             </pg-code>
-          </setup>
           <statement>
             <p>
               [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/mYBwwJSp/width/413/height/331/border/888888" width="413px" height="331px" style="border:0px;" width="431px" height="313px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
@@ -184,7 +182,6 @@
       </introduction>
 
       <webwork>
-          <setup>
             <!-- Within parserFunction below the formula has nothing to do with the problem.  It's only there to be function to generate values for us -->
             <pg-code>
                 $speed = PopUp(["?", "hours", "miles", "hours per mile", "miles per hour"], "miles per hour");
@@ -199,7 +196,6 @@
                 Context()->flags->set(formatStudentAnswer=>"parsed");
                 $difference=Formula("f(5)-f(2)");
             </pg-code>
-          </setup>
           <statement>
             <p>
               [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/ZVx2N298/width/431/height/250/border/888888/smb/false/stb/false/stbh/false/ai/false/asb/false/sri/false/rc/false/ld/false/sdz/false/ctl/false" width="431px" height="250px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
@@ -315,13 +311,11 @@
 
     <exercise>
       <webwork>
-          <setup>
 
             <pg-code>
                 $chngDist = Real(19.5);
                 $meaning = PopUp(["?", "Change in hours since 8 a.m.", "Delta t", "Delta times t", "There is no meaning to this expression"], 1);
             </pg-code>
-          </setup>
           <statement>
             <p>
               [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/ZVx2N298/width/431/height/250/border/888888/smb/false/stb/false/stbh/false/ai/false/asb/false/sri/false/rc/false/ld/false/sdz/false/ctl/false" width="431px" height="250px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
@@ -440,7 +434,6 @@
 
     <exercise>
       <webwork>
-          <setup>
 
             <pg-code>
               $in1=Real(7);
@@ -453,7 +446,6 @@
               $f2=Formula("f(2)");
               $evf2=$f2->cmp()->withPostFilter(AnswerHints(Compute("30") => "That's the actual value, but respond by using function notation."));
             </pg-code>
-          </setup>
           <statement>
             <p>
               Suppose <m>f(x)</m> is a function defined for all real numbers.
@@ -546,7 +538,6 @@
 
     <exercise>
       <webwork>
-          <setup>
 
             <pg-code>
                 $slope1 = Real(-1);
@@ -562,7 +553,6 @@
                 $lineA = ImplicitPlane("y=-x+7");
                 $lineB = ImplicitPlane("y=2x+1");
             </pg-code>
-          </setup>
           <stage>
           <statement>
             <p>
@@ -771,7 +761,6 @@
       </introduction>
 
       <webwork>
-          <setup>
 
             <pg-code>
               $intMay = Real(2.6);
@@ -783,7 +772,6 @@
               Context()->variables->are(m => "Real");
               $intMarch = Compute("3&lt;=m&lt;=12");
             </pg-code>
-          </setup>
           <statement>
             <p>
               [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/PPsZ6cgY/width/431/height/245/border/888888/smb/false/stb/false/stbh/false/ai/false/asb/false/sri/false/rc/false/ld/false/sdz/false/ctl/false" width="431px" height="245px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
@@ -875,7 +863,6 @@
 
     <exercise>
       <webwork>
-          <setup>
 
             <pg-code>
                 $deltaInput = Real(2);
@@ -886,7 +873,6 @@
                 $fzero = Real(-6);
                 $ftwo = Real(-4);
             </pg-code>
-          </setup>
           <statement>
             <p>
               <ol label="a">
@@ -1001,13 +987,11 @@
 
     <exercise>
       <webwork>
-          <setup>
 
             <pg-code>
                 $forward = Real(-1);
                 $backward = Real(-1);
             </pg-code>
-          </setup>
           <statement>
             <p>
               Previously you were given the function <m>f(x) = (x-2)(x+3)</m> and you calculated
@@ -1052,7 +1036,6 @@
 
     <exercise>
       <webwork>
-          <setup>
 
             <pg-code>
                 $delDist = Real(10);
@@ -1067,7 +1050,6 @@
                 $lastUnit = PopUp(["?", "miles", "hours per mile", "hours", "miles per hour"], 4);
                 $interval = PopUp(["?", "2 p.m. and 5 p.m.", "10 a.m. and 1 p.m.", "2 and 5", "2 mph and 5 mph"], 2);
             </pg-code>
-          </setup>
           <statement>
             <p>
               [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/ZVx2N298/width/413/height/250/border/888888" width="413px" height="250px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*

--- a/src/activity-combinations-of-functions.xml
+++ b/src/activity-combinations-of-functions.xml
@@ -472,8 +472,6 @@
             <m>g(x)</m> and <m>P(x)</m>
           </p>
 
-          <sidebyside>
-
             <tabular top="major" halign="center">
               <col halign="left" />
               <col />
@@ -522,8 +520,6 @@
                 <cell><var name="$P[5]" width="10" /></cell>
               </row>
             </tabular>
-
-          </sidebyside>
         </statement>
         <hint>
           <p>
@@ -536,8 +532,6 @@
           </p>
         </hint>
         <solution>
-          <sidebyside>
-
             <tabular top="major" halign="center">
               <col halign="left" />
               <col />
@@ -586,8 +580,6 @@
                 <cell><var name="$P[5]" /></cell>
               </row>
             </tabular>
-
-          </sidebyside>
         </solution>
         </stage>
         <stage>
@@ -595,9 +587,6 @@
           <p>
             You made the table:
           </p>
-
-          <sidebyside>
-
             <tabular top="major" halign="center">
               <col halign="left" />
               <col />
@@ -630,9 +619,6 @@
                 <cell><var name="$P[5]" /></cell>
               </row>
             </tabular>
-
-          </sidebyside>
-
           <p>
             Use the values from your table above to plot six points on the graph of <m>y= P(x)</m>.
             Move the six blue points to those locations and the graph of <m>P(x)</m> will appear.
@@ -780,9 +766,6 @@
                 <p>
                   Consider the <m>x</m> values:
                 </p>
-
-                <sidebyside>
-
                   <tabular halign="left">
                     <row>
                       <cell><m>-3</m></cell>
@@ -792,9 +775,6 @@
                       <cell><m>7</m></cell>
                     </row>
                   </tabular>
-
-                </sidebyside>
-
               </li>
 
               <li>

--- a/src/activity-combinations-of-functions.xml
+++ b/src/activity-combinations-of-functions.xml
@@ -742,7 +742,7 @@
     Remember that this is all about combining the outputs of the <m>f</m> and <m>g</m> functions.
   </p>
 
-  <todo> Finish this problem </todo>
+  <!-- TODO: Finish this problem -->
 
   <exercise>
     <webwork>

--- a/src/activity-combinations-of-functions.xml
+++ b/src/activity-combinations-of-functions.xml
@@ -20,7 +20,6 @@
 
   <exercise>
     <webwork>
-        <setup>
 
           <pg-code>
             $heat=random(80,120,5);
@@ -33,7 +32,6 @@
             parserFunction("f(x)"=>"(sin(x)+2)/pi");
             $billExpression=Formula("h(x)+w(x)");
           </pg-code>
-        </setup>
         <stage>
         <statement>
           <p>
@@ -122,7 +120,6 @@
 
   <exercise>
     <webwork>
-        <setup>
 
         <pg-code>
           $x=random(2,4,1);
@@ -133,7 +130,6 @@
           $p=$M*$N;
           $q=$M/$N;
         </pg-code>
-        </setup>
         <stage>
         <statement>
           <p>
@@ -259,7 +255,6 @@
 
   <exercise>
     <webwork>
-        <setup>
 
         <pg-code>
           $revenue=PopUp(
@@ -272,7 +267,6 @@
           ["?","You sell it for 40 cents more than you paid for it.","You sell it for 40 percent more than you paid for it.","You paid 1.40 for the item."],"You sell it for 40 percent more than you paid for it."
           );
         </pg-code>
-        </setup>
         <stage>
         <statement>
           <p>
@@ -449,7 +443,6 @@
 
   <exercise>
     <webwork>
-        <setup>
 
         <pg-code>
           @x=(-4,0,2,4,6,8);
@@ -460,7 +453,6 @@
           ["?","yes","no"],"yes"
           );
         </pg-code>
-        </setup>
         <stage>
         <statement>
           <p>
@@ -665,7 +657,6 @@
 
   <exercise>
     <webwork>
-        <setup>
 
         <pg-code>
           $f=Compute("-1+0.5*x");
@@ -673,7 +664,6 @@
           $P=Compute("$f*$g");
 
         </pg-code>
-        </setup>
         <statement>
           <p>
             The graph below shows the functions <m>f</m> and <m>g</m>.
@@ -756,14 +746,12 @@
 
   <exercise>
     <webwork>
-        <setup>
 
         <pg-code>
           $hZero=Real(4.4);
           $hPositive=OneOf(0,2.1);
           $hNegative=OneOf(-3,7);
         </pg-code>
-        </setup>
         <statement>
           <p>
             In this problem,

--- a/src/activity-composition.xml
+++ b/src/activity-composition.xml
@@ -29,14 +29,12 @@
 
   <exercise xml:id="area-of-spill">
     <webwork>
-        <setup>
 
           <pg-code>
             Context()->variables->are(t=>'Real', r=>'Real');
             $radiusNum=Real(38);
             $areaNum=Compute("pi*38**2");
           </pg-code>
-        </setup>
         <statement>
           <p>
             An oil spill is in the shape of a circular disk,
@@ -117,7 +115,6 @@
 
   <exercise xml:id="exercise-oil-spill-formulas">
     <webwork>
-        <setup>
 
           <pg-code>
             Context()->variables->are(t=>'Real', r=>'Real');
@@ -125,7 +122,6 @@
             $radiusForm=Compute("10+4t");
             $areaComposed=Compute("pi($radiusForm)^2");
           </pg-code>
-        </setup>
         <statement>
           <p>
             The radius of the circular spill started at <m>10</m> meters,
@@ -208,13 +204,11 @@
 
   <exercise>
     <webwork>
-        <setup>
 
           <pg-code>
             $goff=Real(24);
             $fofg=Real(6);
           </pg-code>
-        </setup>
         <statement>
           <p>
             Let <m>f(x)=x+3</m> and <m>g(x)=x^2-1</m>.
@@ -275,7 +269,6 @@
 
   <exercise>
     <webwork>
-        <setup>
 
           <pg-code>
             @x=map{$_+1}NchooseK(8,4);
@@ -284,7 +277,6 @@
             $g[0]=random(16,20,1);
             $g[1]=$x[1];
           </pg-code>
-        </setup>
         <statement>
           <p>
             Consider two functions <m>f</m> and <m>g</m>,
@@ -374,14 +366,12 @@
 
   <exercise>
     <webwork>
-        <setup>
 
           <pg-code>
             $input=random(1,10,1);
             $g=Compute("3*$input");
             $fofg=Compute("$g**2-$g");
           </pg-code>
-        </setup>
         <statement>
           <p>
             Think about a function like a <em>machine</em>
@@ -553,7 +543,6 @@
 
   <exercise>
     <webwork>
-        <setup>
 
           <pg-code>
             $a=random(5,9,1);
@@ -563,7 +552,6 @@
             $BofL=Compute("x^$b+$a");
             $LofB=Compute("(x+$a)^$b");
           </pg-code>
-        </setup>
         <statement>
           <p>
             Let <m>B(x) = <var name="$B" /></m> and <m>L(x) = <var name="$L" /></m>.
@@ -623,7 +611,6 @@
 
   <exercise>
     <webwork>
-        <setup>
 
           <pg-code>
             @xg=map{($_-6)}NchooseK(14,2);
@@ -635,7 +622,6 @@
             $FofF=abs($F[1]-1)-4;
             $GofG=2-abs($G[1]);
           </pg-code>
-        </setup>
         <statement>
           <p>
             [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/WJymUNhx/width/432/height/373/border/888888/sdz/false/" width="432px" height="373px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*

--- a/src/activity-compounding-number-e.xml
+++ b/src/activity-compounding-number-e.xml
@@ -130,12 +130,10 @@
     <exercise>
       <title><q>Counting</q> the Growth Factor</title>
       <webwork>
-          <setup>
 
           <pg-code>
             $drop = PopUp(["?", "is constant", "increases", "decreases", "none of the above"], "decreases");
           </pg-code>
-          </setup>
           <statement>
             <p>
               Consider the expression
@@ -276,7 +274,6 @@
     <exercise>
       <title>Interpret the meaning of the fractional exponent</title>
       <webwork>
-          <setup>
 
           <pg-code>
               $init= Real(1350);
@@ -286,7 +283,6 @@
               $per=Real(8.20);
               $m3 = PopUp(["?", "An 8.2 percent increase occurs every five years", "An 8.2 percent increase occurs five times each year", "An 8.2 percent increase is divided into five equal parts", "An 8.2 percent increase is multiplied by 5"], "An 8.2 percent increase occurs every five years");
           </pg-code>
-          </setup>
           <statement>
             <p>
               <ol label="a">
@@ -663,7 +659,6 @@
     <!-- <exercise>
       <title>Review of Fractional Exponents</title>
       <webwork>
-        <setup>
           <pg-code>
             $fifth = RadioButtons(
             ["False","True"],
@@ -678,7 +673,6 @@
             1, labels => ["False","True"],displayLabels => 0
             );
           </pg-code>
-        </setup>
         <statement>
           <p><m>\frac{t}{1/5} = 5t</m></p>
           <p><var name="$fifth" form="buttons" /></p>
@@ -767,7 +761,6 @@
 
     <exercise>
       <webwork>
-          <setup>
 
           <pg-code>
             $true = RadioButtons(
@@ -775,7 +768,6 @@
             0, labels => ["true","false"],displayLabels => 0
             );
           </pg-code>
-          </setup>
           <stage>
           <statement>
             <p>
@@ -1087,7 +1079,6 @@
       </introduction>
 
       <webwork>
-          <setup>
 
             <pg-code>
                 $num= Real(12);
@@ -1095,7 +1086,6 @@
                 $times2 = PopUp(["?", "Investment is compounded continously thoughout the year", "Investment is compounded every 12 years", "Investment is compounded 12 times each year", "Investment grows by 12 percent"], "Investment is compounded every 12 years");
                 $times3 = PopUp(["?", "Investment is compounded continously thoughout the year", "Investment is compounded every 12 years", "Investment is compounded 12 times each year", "Investment grows by 12 percent"], "Investment is compounded continously thoughout the year");
             </pg-code>
-          </setup>
           <statement>
             <p>
               The value of an investment is modeled by the equation

--- a/src/activity-compounding-number-e.xml
+++ b/src/activity-compounding-number-e.xml
@@ -418,7 +418,6 @@
       <title>A decrease of <m>20 \%</m> every <m>5</m> years</title>
       <webwork>
           <statement>
-            <sidebyside>
 
               <tabular top="medium" bottom="medium" left="medium" right="medium">
                 <col halign="center"/>
@@ -463,7 +462,6 @@
                 </row>
               </tabular>
 
-            </sidebyside>
           </statement>
           <solution>
             <p>
@@ -863,8 +861,6 @@
                     and <m>V</m> the value of the loan in dollars after one year.(round the money values to the nearest cent)
                   </p>
 
-                  <sidebyside>
-
                     <tabular top="medium" bottom="medium" left="medium" right="medium">
                       <col halign="center"/>
                       <col halign="center"/>
@@ -881,8 +877,6 @@
                         <cell><var name="3044.24" width="8" /></cell>
                       </row>
                     </tabular>
-
-                  </sidebyside>
 
                 </li>
               </ol>

--- a/src/activity-describing-functions.xml
+++ b/src/activity-describing-functions.xml
@@ -64,7 +64,6 @@
             <introduction><p>You may use inequality or interval notation to answer the questions below.</p>
             </introduction>
             <webwork>
-                <setup>
 
                     <pg-code>
                         Context("Inequalities");
@@ -72,7 +71,6 @@
                         $answer2 = Compute("x&lt;-2orx&gt;=1");
                         $answer3 = Compute("x&lt;=-2orx&gt;=1");
                     </pg-code>
-                </setup>
 
                 <statement>
                     <p>Remember that open circles mean <q>include</q> while closed circles mean <q>not include</q>.</p>
@@ -99,7 +97,6 @@
 -->
     <exercise>
       <webwork>
-          <setup>
             <pg-code>
                       @ticks = ();
                       for my $j (-5..5) {push(@ticks,$j);};
@@ -145,7 +142,6 @@
                       $in[1] = Compute("x&lt;-2orx&gt;=1");
                       $in[2] = Compute("x&lt;=-2orx&gt;=1");
             </pg-code>
-          </setup>
           <statement>
             <p>
               Remember that closed circles mean <q>include</q>
@@ -315,13 +311,11 @@
     <exercise xml:id="exercise-pos-neg">
       <title>Positive or Negative</title>
       <webwork>
-          <setup>
 
             <pg-code>
                 $positive = RadioButtons(["below the horizontal axis.","above the horizontal axis."],1);
                 $negative = RadioButtons(["below the horizontal axis.","above the horizontal axis."],0);
             </pg-code>
-          </setup>
           <statement>
             <p>
               [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/sHzc76gr/width/431/height/313/border/888888/sri/true" width="431px" height="313px" style="border:0px;" width="431px" height="313px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
@@ -387,7 +381,6 @@
     <exercise xml:id="exercise-inc-dec">
       <title>Increasing or Decreasing</title>
       <webwork>
-          <setup>
 
             <pg-code>
               $Increasing = RadioButtons(["as input increases, output increases.","as input increases, output decreases."],0);
@@ -398,7 +391,6 @@
               $dec1 = Compute("2&lt;=x&lt;=4");
               $dec2 = Compute("6&lt;=x&lt;=8");
             </pg-code>
-          </setup>
           <statement>
             <p>
               [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/pbwn6UAF/width/431/height/230/border/888888/smb/false/stb/false/stbh/false/ai/false/asb/false/sri/false/rc/false/ld/false/sdz/false/ctl/false" width="431px" height="230px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
@@ -483,13 +475,11 @@
     <exercise xml:id="exercise-concavity">
       <title>Concave Up or Concave Down</title>
       <webwork>
-          <setup>
 
             <pg-code>
                 $cUp = RadioButtons(["concave up.","concave down."],0);
                 $cDwn = RadioButtons(["concave up.","concave down."],1);
             </pg-code>
-          </setup>
           <statement>
             <p>
               [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/NrncRJR3/width/431/height/300/border/888888/sri/true" width="431px" height="300px" style="border:0px;" width="431px" height="313px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
@@ -534,7 +524,6 @@
 
     <exercise xml:id="exercise-increasing-decreasing">
       <webwork>
-          <setup>
 
             <pg-code>
                 Context("Inequalities");
@@ -549,7 +538,6 @@
                 $cUp2 = Compute("21&lt;=t&lt;=24");
                 $cDwn = Compute("9&lt;=t&lt;=21");
             </pg-code>
-          </setup>
           <statement>
             <p>
               [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/tmanmNPG/width/431/height/300/border/888888/sri/true" width="431px" height="300px" style="border:0px;" width="431px" height="313px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
@@ -699,7 +687,6 @@
 
     <exercise>
       <webwork>
-          <setup>
 
             <pg-code>
               $positive=PopUp(
@@ -718,7 +705,6 @@
               ["?","concave up","concave down"],"concave up"
               );
             </pg-code>
-          </setup>
           <stage>
           <statement>
             <p>

--- a/src/activity-describing-functions.xml
+++ b/src/activity-describing-functions.xml
@@ -152,9 +152,7 @@
               <ol label="a">
                 <li>
 
-                  <sidebyside widths="67%">
-                    <image pg-name="$nl[0]" />
-                  </sidebyside>
+                  <image pg-name="$nl[0]" width="67%"/>
 
                   <p>
                     Represent the shaded region above with an inequality,
@@ -169,9 +167,7 @@
 
                 <li>
 
-                  <sidebyside widths="67%">
-                    <image pg-name="$nl[1]" />
-                  </sidebyside>
+                  <image pg-name="$nl[1]" width="67%"/>
 
                   <p>
                     Represent the shaded region above with an inequality,
@@ -186,9 +182,7 @@
 
                 <li>
 
-                  <sidebyside widths="67%">
-                    <image pg-name="$nl[2]" />
-                  </sidebyside>
+                  <image pg-name="$nl[2]" width="67%"/>
 
                   <p>
                     Represent the shaded region above with an inequality,

--- a/src/activity-domain-range.xml
+++ b/src/activity-domain-range.xml
@@ -86,8 +86,6 @@
               Enter the cost of buying <m>N</m> t-shirts.
             </p>
 
-            <sidebyside>
-
               <tabular top="medium" bottom="medium" left="medium" right="medium">
                 <col halign="center"/>
                 <col halign="center"/>
@@ -120,8 +118,6 @@
                   <cell><var name="65" width="5" /></cell>
                 </row>
               </tabular>
-
-            </sidebyside>
 
             <p>
               <ol label="a">

--- a/src/activity-domain-range.xml
+++ b/src/activity-domain-range.xml
@@ -67,7 +67,6 @@
       </introduction>
 
       <webwork>
-          <setup>
 
             <pg-code>
               $yes = RadioButtons(
@@ -81,7 +80,6 @@
               $integers = PopUp(["?","all integers","all real numbers","only non-negative integers","only zero to 100"],"only non-negative integers");
               $thirteen = PopUp(["?","only positive numbers","all real numbers","only whole numbers","non-negative integer multiples of 13"],"non-negative integer multiples of 13");
             </pg-code>
-          </setup>
           <statement>
             <p>
               T-shirt cost function:
@@ -279,7 +277,6 @@
     <exercise>
       <title>Polynomials</title>
       <webwork>
-          <setup>
 
           <pg-code>
             $yes1 = PopUp(["?","yes","no"],"yes");
@@ -287,7 +284,6 @@
             $no = PopUp(["?","yes","no"],"no");
             $domain = PopUp(["?","only positive numbers","all real numbers","only negative numbers","only numbers ending in C"],"all real numbers");
           </pg-code>
-          </setup>
           <stage>
           <statement>
             <p>
@@ -349,7 +345,6 @@
 
     <exercise>
       <webwork>
-          <setup>
 
           <pg-code>
             $pos1 = PopUp(["?","positive","negative"],"positive");
@@ -357,7 +352,6 @@
             $no = PopUp(["?","yes","no"],"no");
             $range = PopUp(["?","only positive numbers","all real numbers","only negative numbers","all real numbers greater than or equal to zero"],"all real numbers greater than or equal to zero");
           </pg-code>
-          </setup>
           <statement>
             <p>
               [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/FRZgk5eU/width/413/height/350/border/888888" width="413px" height="350px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
@@ -682,7 +676,6 @@
 
     <exercise>
       <webwork>
-          <setup>
 
             <pg-code>
               Context("Inequalities");
@@ -694,7 +687,6 @@
               displayLabels => 0
               );
             </pg-code>
-          </setup>
           <stage>
           <statement>
             <p>
@@ -766,7 +758,6 @@
     <exercise>
       <title>Practice with Roots and Denominators</title>
       <webwork>
-          <setup>
 
             <pg-code>
               Context("Inequalities");
@@ -776,7 +767,6 @@
               $dom3 = Compute("x!=7");
               $dom4 = Compute("x!= -3 and x!= 3");
             </pg-code>
-          </setup>
           <statement>
             <p>
               Remember that typing <m>x!=a</m> means
@@ -899,7 +889,6 @@
 
     <exercise>
       <webwork>
-          <setup>
 
           <pg-code>
             Context("Inequalities");
@@ -909,7 +898,6 @@
             $rng1 = Compute("-3&lt;=y&lt;=-0.5");
             $rng2 = Compute("2&lt;y&lt;=8");
           </pg-code>
-          </setup>
           <stage>
           <statement>
             <p>
@@ -1010,7 +998,6 @@
 
     <exercise>
       <webwork>
-          <setup>
 
             <pg-code>
               Context("Inequalities");
@@ -1019,7 +1006,6 @@
               $rng2 = Compute("0.78&lt;=y&lt;4.62");
               $rng3 = Compute("1.95&lt;=y&lt;4.62");
             </pg-code>
-          </setup>
           <stage>
           <statement>
             <p>

--- a/src/activity-end-behavior-and-asymptotes.xml
+++ b/src/activity-end-behavior-and-asymptotes.xml
@@ -19,7 +19,6 @@
     <p>In the next exercise, you will see how a horizontal <term>asymptote</term> of a function can be seen by a table of values.</p>
     <exercise>
       <webwork>
-        <setup>
           <pg-code>
             @x=(1, 10, 100, 1000, 10000);
             $a=12*random(2, 5, 1);
@@ -29,7 +28,6 @@
             $variable=PopUp(["?","x","y"],"y");
             $value=$a/$c;
           </pg-code>
-        </setup>
         <statement>
           <p>The table below shows values of the function: <me>f(x) = \frac{<var name="$a" />x + <var name="$b" />}{<var name="$c" />x}</me></p>
           <table>
@@ -86,7 +84,6 @@
     <p>In the next four exercises, you will examine the end-behavior of a polynomial and learn to predict this end-behavior by observing its formula.</p>
     <exercise>
       <webwork>
-        <setup>
 
           <pg-code>
             $compare=PopUp(["?","very different","very similar"],"very similar");
@@ -94,7 +91,6 @@
             $power=PopUp(["?","x^2","x^3"],"x^3");
             $term=Compute("x^3");
           </pg-code>
-        </setup>
         <statement>
           <p>The graph below shows: <me>f(x) = x(x+3)(x-4)</me></p>
           <p>[@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/Abx2UAXB/width/425/height/373/border/888888" width="425px" height="373px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*</p>
@@ -115,12 +111,10 @@
 
     <exercise>
       <webwork>
-        <setup>
 
           <pg-code>
             $function=PopUp(["?","x^2","x^3","x^4","x^5"],"x^4");
           </pg-code>
-        </setup>
         <statement>
           <p>There is a lot going on in the following graph.</p>
           <p>The two "vertical" lines are actually just part of the graph of: <me>g(x) = (x-1)(x+4)(x-5)(x+2)</me></p>
@@ -151,7 +145,6 @@
     <p>So, in the next exercise, you will get practice finding the leading term of a polynomial.</p>
     <exercise>
       <webwork>
-        <setup>
 
           <pg-code>
             @a=map{2+$_}NchooseK(15,9);
@@ -161,7 +154,6 @@
             $vars4=PopUp(["?","x^2","x^3","x^4"],"x^4");
             $vars3=PopUp(["?","x^2","x^3","x^4"],"x^3");
           </pg-code>
-        </setup>
         <statement>
           <p>For each polynomial below, determine its leading term.</p>
           <p>Enter the coefficient in the blank, and then choose the correct power of <m>x</m> with the drop-down.</p>
@@ -187,14 +179,12 @@
 
     <exercise>
       <webwork>
-        <setup>
 
           <pg-code>
             $left=PopUp(["?","Up","Down"],"Down");
             $right=PopUp(["?","Up","Down"],"Up");
             $end=PopUp(["?","x","x^2","x^3"],"x^3");
           </pg-code>
-        </setup>
         <statement>
           <p>This problem concerns the polynomial <me>f(x) = x(x - 2)(x + 3)</me>and your goal is to predict the end-behavior. Think about the power function which has the same end-behavior as <m>f(x)</m>.</p>
           <p>[@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/NcwafvMp/width/427/height/392/border/888888" width="427px" height="392px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*</p>

--- a/src/activity-end-behavior-and-asymptotes.xml
+++ b/src/activity-end-behavior-and-asymptotes.xml
@@ -30,7 +30,7 @@
           </pg-code>
         <statement>
           <p>The table below shows values of the function: <me>f(x) = \frac{<var name="$a" />x + <var name="$b" />}{<var name="$c" />x}</me></p>
-          <table>
+          <figure>
             <tabular top="major" halign="center">
               <col halign="left" />
               <col halign="left" />
@@ -65,7 +65,7 @@
                 <cell><m><var name="$y[4]" /></m></cell>
               </row>
             </tabular>
-          </table>
+          </figure>
           <p>What appears to be the horizontal asymptote of <m>f(x)</m>?</p>
           <p>Answer:  <var name="$variable" form="popup" /> = <var name="$value" width="10" /></p>
 

--- a/src/activity-end-behavior-and-asymptotes.xml
+++ b/src/activity-end-behavior-and-asymptotes.xml
@@ -76,11 +76,11 @@
         </solution>
       </webwork>
     </exercise>
-    <p>Now, this behavior shows up in the graph by the function <m>f(x)</m> "flattening out" to the left or the right. This is an example of what is called <term>end-behavior</term> (or <term>long-run behavior</term>). From a graphical perspective, <term>end-behavior</term> is about what the graph tends to do as the input <m>x</m> gets far from zero.</p>
-<todo>Make tikz pictures for y = 8*2^(-x^2) - 11 and y = (10x - 7)/(2x), sidebyside, with the labels "horizontal asymptote y = -3" and "horizontal asymptote y = 5" </todo>
-<todo>This will take the place of these GeoGebra graphs</todo>
+    <p>Now, this behavior shows up in the graph by the function <m>f(x)</m> "flattening out" to the left or the right. This is an example of what is called <term>end-behavior</term> (or <term>long-run behavior</term>). From a graphical perspective, <term>end-behavior</term> is about what the graph tends to do as the input <m>x</m> gets far from zero.</p> -->
+    <!-- TODO: Make tikz pictures for y = 8*2^(-x^2) - 11 and y = (10x - 7)/(2x), sidebyside, with the labels "horizontal asymptote y = -3" and "horizontal asymptote y = 5" -->
+    <!-- TODO: This will take the place of these GeoGebra graphs -->
 
-    <p>As you know, not every function has a horizontal asymptote. For example, power functions do not "flatten out", but rather they either increase toward <m>\infty</m> (point upward) or decrease toward <m>-\infty</m> (point downward). So, <term>end-behavior</term> may be just that &#8212; the graph increasing or decreasing forever.</p>
+    <!-- <p>As you know, not every function has a horizontal asymptote. For example, power functions do not "flatten out", but rather they either increase toward <m>\infty</m> (point upward) or decrease toward <m>-\infty</m> (point downward). So, <term>end-behavior</term> may be just that &#8212; the graph increasing or decreasing forever.</p>
     <p>In the next four exercises, you will examine the end-behavior of a polynomial and learn to predict this end-behavior by observing its formula.</p>
     <exercise>
       <webwork>

--- a/src/activity-exponential-intro.xml
+++ b/src/activity-exponential-intro.xml
@@ -635,8 +635,6 @@
           </pg-code>
           <stage>
           <statement>
-            <sidebyside>
-
               <tabular top="medium" bottom="medium" left="medium" right="medium">
                 <col halign="center"/>
                 <col halign="center"/>
@@ -669,9 +667,6 @@
                   <cell><m>14.22</m></cell>
                 </row>
               </tabular>
-
-            </sidebyside>
-
             <p>
               Are the outputs changing by repeated addtion or by repeated multiplication?
             </p>
@@ -728,7 +723,6 @@
           </pg-code>
           <stage>
           <statement>
-            <sidebyside>
 
               <tabular top="medium" bottom="medium" left="medium" right="medium">
                 <col halign="center"/>
@@ -762,8 +756,6 @@
                   <cell><m>14.90</m></cell>
                 </row>
               </tabular>
-
-            </sidebyside>
 
             <p>
               Are the outputs are changing by repeated addtion or by repeated multiplication?
@@ -866,8 +858,6 @@
                     Complete the table for a dosage rate reduced by <m>5</m> mg/hour each hour.
                   </p>
 
-                  <sidebyside>
-
                     <tabular top="medium" bottom="medium" left="medium" right="medium">
                       <col halign="center"/>
                       <col halign="center"/>
@@ -896,8 +886,6 @@
                         <cell><var name="230" width="5" /></cell>
                       </row>
                     </tabular>
-
-                  </sidebyside>
 
                 </li>
               </ol>
@@ -973,8 +961,6 @@
                     (<em>round your answers to <m>2</m> decimal places</em>).
                   </p>
 
-                  <sidebyside>
-
                     <tabular top="medium" bottom="medium" left="medium" right="medium">
                       <col halign="center"/>
                       <col halign="center"/>
@@ -1004,8 +990,6 @@
                       </row>
                     </tabular>
 
-                  </sidebyside>
-
                 </li>
               </ol>
             </p>
@@ -1029,9 +1013,6 @@
                 </li>
 
                 <li>
-
-                  <sidebyside>
-
                     <tabular top="medium" bottom="medium" left="medium" right="medium">
                       <col halign="center"/>
                       <col halign="center"/>
@@ -1061,8 +1042,6 @@
                       </row>
                     </tabular>
 
-                  </sidebyside>
-
                 </li>
               </ol>
             </p>
@@ -1085,8 +1064,6 @@
                     This time instead of the actual results,
                     write the initial value followed by multiples of the growth factor for every hour that passes.
                   </p>
-
-                  <sidebyside>
 
                     <tabular top="medium" bottom="medium" left="medium" right="medium">
                       <col halign="center"/>
@@ -1116,8 +1093,6 @@
                         <cell><m>250</m>(<var name="0.98" width="3" />)(<var name="0.98" width="3" />)(<var name="0.98" width="3" />)(<var name="0.98" width="3" />)</cell>
                       </row>
                     </tabular>
-
-                  </sidebyside>
 
                 </li>
               </ol>
@@ -1358,8 +1333,6 @@
               Use our growth factor <m><var name="$b" /></m> to continue the pattern in the table.
             </p>
 
-            <sidebyside>
-
               <tabular top="major" halign="center">
                 <col halign="left" />
                 <col halign="left" />
@@ -1389,8 +1362,6 @@
                 </row>
               </tabular>
 
-            </sidebyside>
-
             <p>
               Notice there is a pattern emerging.
               For every hour that passes there is another multiple of the same growth factor.
@@ -1415,8 +1386,6 @@
                     on the right.
                   </p>
 
-                  <sidebyside>
-
                     <tabular top="major" halign="center">
                       <col halign="left" />
                       <col halign="left" />
@@ -1430,8 +1399,6 @@
                       </row>
                     </tabular>
 
-                  </sidebyside>
-
                 </li>
 
                 <li>
@@ -1439,8 +1406,6 @@
                     Finally, at any time <m>t</m>,
                     what is the resulting formula?
                   </p>
-
-                  <sidebyside>
 
                     <tabular top="major" halign="center">
                       <col halign="left" />
@@ -1454,8 +1419,6 @@
                         <cell><var name="$y[6]" width="20" evaluator="$ev[6]"/></cell>
                       </row>
                     </tabular>
-
-                  </sidebyside>
 
                   <p>
                     This is your formula to calculate the population at any time!
@@ -2525,8 +2488,6 @@
 
                 <li>
 
-                  <sidebyside>
-
                     <tabular top="medium" bottom="medium" left="medium" right="medium">
                       <col halign="center"/>
                       <col halign="center"/>
@@ -2563,8 +2524,6 @@
                         <cell><var name="$time[6]" width="10"/></cell>
                       </row>
                     </tabular>
-
-                  </sidebyside>
 
                 </li>
 
@@ -2638,8 +2597,6 @@
 
                 <li>
 
-                  <sidebyside>
-
                     <tabular top="medium" bottom="medium" left="medium" right="medium">
                       <col halign="center"/>
                       <col halign="center"/>
@@ -2676,8 +2633,6 @@
                         <cell><var name="$t2[6]" width="10"/></cell>
                       </row>
                     </tabular>
-
-                  </sidebyside>
 
                 </li>
 
@@ -2758,8 +2713,6 @@
               Round your answers to <m>3</m> decimal places.
             </p>
 
-            <sidebyside>
-
               <tabular top="medium" bottom="medium" left="medium" right="medium">
                 <col halign="center"/>
                 <col halign="center"/>
@@ -2785,8 +2738,6 @@
                 </row>
               </tabular>
 
-            </sidebyside>
-
             <p>
               Notice that even at <m>t=40</m> the answer is small, but it is not zero.
             </p>
@@ -2799,8 +2750,6 @@
             </p>
           </statement>
           <solution>
-            <sidebyside>
-
               <tabular top="medium" bottom="medium" left="medium" right="medium">
                 <col halign="center"/>
                 <col halign="center"/>
@@ -2825,8 +2774,6 @@
                   <cell><m>0.002</m></cell>
                 </row>
               </tabular>
-
-            </sidebyside>
           </solution>
           </stage>
           <stage>

--- a/src/activity-exponential-intro.xml
+++ b/src/activity-exponential-intro.xml
@@ -260,7 +260,6 @@
       </introduction>
 
       <webwork>
-          <setup>
 
             <pg-code>
                 $thirtyNine = Real(39);
@@ -269,7 +268,6 @@
                 $Increase = PopUp(["?", "Increase", "Decrease", "None of the above", "All of the above"], "Increase");
                 $Decrease = PopUp(["?", "Increase", "Decrease", "None of the above", "All of the above"], "Decrease");
             </pg-code>
-          </setup>
           <statement>
             <p>
               <ol label="a">
@@ -360,14 +358,12 @@
       </introduction>
 
       <webwork>
-          <setup>
 
             <pg-code>
                 $b = Compute(10000/2000);
                 $r = Compute(4);
                 $rPercent = Compute(400);
             </pg-code>
-          </setup>
           <statement>
             <p>
               A percent change implies multiplication by a growth factor.
@@ -445,14 +441,12 @@
       </introduction>
 
       <webwork>
-          <setup>
 
             <pg-code>
                 $b = Compute(0.20);
                 $r = Compute(0.80);
                 $rPercent = Compute(80);
             </pg-code>
-          </setup>
           <statement>
             <p>
               A percent change implies multiplication by a growth factor.
@@ -633,14 +627,12 @@
       </introduction>
 
       <webwork>
-          <setup>
           <pg-code>
             $add = RadioButtons(
             ["repeated multiplication","repeated addition"],
             1, labels => ["repeated multiplication","repeated addition"],displayLabels => 0
             );
           </pg-code>
-          </setup>
           <stage>
           <statement>
             <sidebyside>
@@ -728,14 +720,12 @@
       </introduction>
 
       <webwork>
-          <setup>
           <pg-code>
             $mult = RadioButtons(
             ["repeated multiplication","repeated addition"],
             0, labels => ["repeated multiplication","repeated addition"],displayLabels => 0
             );
           </pg-code>
-          </setup>
           <stage>
           <statement>
             <sidebyside>
@@ -858,13 +848,11 @@
       </introduction>
 
       <webwork>
-          <setup>
 
           <pg-code>
           Context()->variables->are(t=>'Real',D=>'Real');
             $line = ImplicitPlane("D=-5t+250");
           </pg-code>
-          </setup>
           <stage>
           <statement>
             <p>
@@ -1209,12 +1197,10 @@
       </introduction>
 
       <webwork>
-          <setup>
 
             <pg-code>
                 $Next1 = Real(165);
             </pg-code>
-          </setup>
           <statement>
             <p>
               Sometimes, the way a list of values is written can make it easy or hard to determine the pattern.
@@ -1304,7 +1290,6 @@
       </introduction>
 
       <webwork>
-          <setup>
 
               <pg-code>
                 Context()->variables->are(t=>'Real');
@@ -1347,7 +1332,6 @@
                 return 1;
           });}
               </pg-code>
-          </setup>
           <stage>
           <statement>
             <p>
@@ -1581,7 +1565,6 @@
       </introduction>
 
       <webwork>
-          <setup>
 
           <pg-code>
             $same = RadioButtons(
@@ -1589,7 +1572,6 @@
             0, labels => ["yes","no"],displayLabels => 0
             );
           </pg-code>
-          </setup>
           <statement>
             <p>
               <ol label="a">
@@ -1644,7 +1626,6 @@
       </introduction>
 
       <webwork>
-          <setup>
 
           <pg-code>
             $same = RadioButtons(
@@ -1652,7 +1633,6 @@
             1, labels => ["yes","no"],displayLabels => 0
             );
           </pg-code>
-          </setup>
           <stage>
           <statement>
             <p>
@@ -1839,7 +1819,6 @@
       </introduction>
 
       <webwork>
-          <setup>
 
             <pg-code>
             Context()->variables->are(t=>'Real');
@@ -1849,7 +1828,6 @@
               $b=Real(1+$r);
               $bRoot=Real($b**(1/3));
             </pg-code>
-          </setup>
           <stage>
           <statement>
             <p>
@@ -2006,7 +1984,6 @@
       </introduction>
 
       <webwork>
-          <setup>
 
             <pg-code>
             Context()->variables->are(t=>'Real');
@@ -2019,7 +1996,6 @@
               $p=Real($r*100);
               $pRoot=Real($rRoot*100);
             </pg-code>
-          </setup>
           <stage>
           <statement>
             <p>
@@ -2258,7 +2234,6 @@
       </introduction>
 
       <webwork>
-          <setup>
 
           <pg-code>
           Context()->variables->are(t=>'Real');
@@ -2273,7 +2248,6 @@
             $compounded=Real(5);
             $initialTemp=$a/($bRoot**3);
           </pg-code>
-          </setup>
           <stage>
           <statement>
             <p>
@@ -2511,7 +2485,6 @@
       </introduction>
 
       <webwork>
-          <setup>
 
             <pg-code>
                 $dInit = Real(150);
@@ -2526,7 +2499,6 @@
                 $a=Real(25);
                 @time=map{$dInit-$a*$_}(0..6);
             </pg-code>
-          </setup>
           <statement>
             <p>
               <ol label="a">
@@ -2629,7 +2601,6 @@
       </introduction>
 
       <webwork>
-          <setup>
 
             <pg-code>
                 $dInit = Real(150);
@@ -2645,7 +2616,6 @@
                 $b=1-$r;
                 @t2=map{$dInit*$b**$_}(0..6);
             </pg-code>
-          </setup>
           <statement>
             <p>
               <ol label="a">

--- a/src/activity-function-notation.xml
+++ b/src/activity-function-notation.xml
@@ -102,7 +102,6 @@
       </introduction>
 
       <webwork>
-          <setup>
 
             <pg-code>
                 for my $i (0,1) {
@@ -134,7 +133,6 @@
                 parser::Assignment->Allow;
                 $solve=Formula("F=-7.6");
             </pg-code>
-          </setup>
           <statement>
             <p>
               Our function is a graph,
@@ -296,7 +294,6 @@
 
     <exercise>
       <webwork seed="1">
-          <setup>
 
             <pg-code>
                 $time = Real(random(2,7,1));
@@ -304,7 +301,6 @@
                 $position = Real(40*exp(2.6*($time-2))/(1+exp(2.6*($time-2)))+10);
                 $units = PopUp(["?", "miles", "hours", "miles per hour", "hours per mile"], "miles");
             </pg-code>
-          </setup>
           <statement>
             <p>
               Consider the graph below.
@@ -535,14 +531,12 @@
 
     <exercise>
       <webwork>
-          <setup>
 
             <pg-code>
                 $tarzan = PopUp(["?","Tarzan times the jungle","Tarzan jungle","Tarzan of the jungle","Jungle after Tarzan"],"Tarzan of the jungle");
                 $helen = PopUp(["?","Helen loves Troy","Helen multiplied by Troy","Helen next to Troy","Helen of Troy"],"Helen of Troy");
                 $f = PopUp(["?","f of x","f times x","f parentheses x","f x"],"f of x");
             </pg-code>
-          </setup>
           <statement>
             <p>
               How would you say the function notation in each statement below?
@@ -634,7 +628,6 @@
 
     <exercise>
       <webwork>
-          <setup>
 
             <pg-code>
                 $distance = Real(10);
@@ -648,7 +641,6 @@
                 $f2=Formula("f(2)");
                 $evf2=$f2->cmp()->withPostFilter(AnswerHints(Compute("30") => "That's the actual value, but respond by using function notation."));
             </pg-code>
-          </setup>
           <statement>
             <p>
               The graph below is a function that illustrates a train's distance from downtown,
@@ -706,7 +698,6 @@
 
     <exercise>
       <webwork>
-          <setup>
 
             <pg-code>
                 $squarefeet= Real(900);
@@ -715,7 +706,6 @@
                 $units = PopUp(["?", "cents", "turtles", "yen", "dollars"], "dollars");
                 $meaning = PopUp(["?", "900 houses have 209,700 dollars", "A 900 dollar house is 209,700 sq. feet", "A 900 sq. ft. house has a value of 209,700 dollars", "Multiply the sq. ft. by 900 to get the value of 209,700 dollars"], "A 900 sq. ft. house has a value of 209,700 dollars");
             </pg-code>
-          </setup>
           <statement>
             <p>
               Let <m>V = f(A)</m> be a function in which the input is the area of a house
@@ -805,7 +795,6 @@
 
     <exercise>
       <webwork>
-          <setup>
 
             <pg-code>
                 $situation1 = RadioButtons(
@@ -817,7 +806,6 @@
                      0,
                 );
             </pg-code>
-          </setup>
           <statement>
             <p>
               In this problem, we have the function <m>y = f(x)</m>,
@@ -914,13 +902,11 @@
     <exercise>
       <title>Determine if the relation in each table is a function or not</title>
       <webwork>
-          <setup>
 
             <pg-code>
               $table1 = RadioButtons(["y is a function of x","y is not a function of x"],1);
               $table2 = RadioButtons(["y is a function of x","y is not a function of x"],0);
             </pg-code>
-          </setup>
           <statement>
             <p>
               <ol label="A">
@@ -1029,13 +1015,11 @@
     <exercise>
       <title>Determine if each equation makes <m>y</m> a function of <m>x</m></title>
       <webwork>
-          <setup>
 
             <pg-code>
               $eq1 = RadioButtons(["y is a function of x","y is not a function of x"],0);
               $eq2 = RadioButtons(["y is a function of x","y is not a function of x"],1);
             </pg-code>
-          </setup>
           <statement>
             <p>
               <ol label="a">
@@ -1121,13 +1105,11 @@
     <exercise>
       <title>Determine if the graph is a function</title>
       <webwork>
-          <setup>
 
             <pg-code>
               $nopass = RadioButtons(["This graph is a function","This graph is not a function"],1);
               $pass = RadioButtons(["This graph is a function","This graph is not a function"],0);
             </pg-code>
-          </setup>
           <statement>
             <p>
               Drag the input left or right to see the results on each graph.
@@ -1207,14 +1189,12 @@
 
     <exercise xml:id="exercise-vertical-line-test">
       <webwork>
-          <setup>
 
             <pg-code>
                 $none = Real(1);
                 $no = RadioButtons(["Passes Vertical Line Test","Does not pass Vertical Line Test"],1);
                 $yes = RadioButtons(["Passes Vertical Line Test","Does not pass Vertical Line Test"],0);
             </pg-code>
-          </setup>
           <statement>
             <p>
               Drag the input to change the position of the vertical line.
@@ -1281,13 +1261,11 @@
 
     <exercise>
       <webwork>
-          <setup>
 
             <pg-code>
                 $dist= Real(40);
                 $miles = PopUp(["?", "feet", "miles", "light years", "meters"], "miles");
             </pg-code>
-          </setup>
           <statement>
             <sidebyside>
 
@@ -1374,7 +1352,6 @@
 
     <exercise>
       <webwork>
-          <setup>
 
             <pg-code>
                 $in1 = Real(1);
@@ -1382,7 +1359,6 @@
                 $output1 = Real(60);
                 $output2 = Real(110);
             </pg-code>
-          </setup>
           <statement>
             <p>
               Let <m>f(x) = 50x + 10</m>.
@@ -1426,7 +1402,6 @@
 
     <exercise>
       <webwork>
-          <setup>
 
             <pg-code>
                 $output1 = Real(0);
@@ -1434,7 +1409,6 @@
                 $output3 = Real(0);
                 $output4 = Real(-1.54);
             </pg-code>
-          </setup>
           <statement>
             <p>
               The graph the the function <m>y = f(x)</m> is shown below.
@@ -1546,7 +1520,6 @@
 
     <exercise>
       <webwork>
-          <setup>
             <pg-code>
                 $five = Real(5);
                 $out = Real(20);
@@ -1558,7 +1531,6 @@
                 $Qexp=Compute("Q**2-Q");
                 $expression=Compute("(x-12)**2-(x-12)");
             </pg-code>
-          </setup>
           <statement>
             <p>
               Use the function <m>f(x) = x^2 - x</m> to evaluate <m>f(5)</m>.
@@ -1762,7 +1734,6 @@
     <exercise>
       <webwork>
           <title>Solving Graphically</title>
-          <setup>
 
             <pg-code>
                 $numZeros = 3;
@@ -1775,7 +1746,6 @@
                 $minNumSolutions = 1;
 
             </pg-code>
-          </setup>
           <stage>
           <statement>
             <p>
@@ -2009,7 +1979,6 @@
 <!-- In the following exercise, the graph tries to show b=1 as giving just one solution, but it is actually approximately 1.0020338293068. Maybe the equation should be rewritten so it has one, nice, unrounded value of b. -->
     <exercise>
       <webwork>
-          <setup>
 
             <pg-code>
                 $b = 0.55/ln(2) - 0.55*ln(0.5/ln(2)) / ln(2);
@@ -2029,7 +1998,6 @@
                    return (($student = $b)?1:0);
                  });
             </pg-code>
-          </setup>
           <statement>
             <p>
               The graphs of two functions are shown.
@@ -2177,7 +2145,6 @@
 
     <exercise>
       <webwork>
-          <setup>
 
             <pg-code>
               Context('Numeric');
@@ -2190,7 +2157,6 @@
               $soln2 = Compute("($out2-$b)/$m");
               $soln3 = Compute("$m*$in+$b");
             </pg-code>
-          </setup>
           <statement>
             <p>
               For the function <m>f(x) = <var name="$m" />x + <var name="$b" /></m>,

--- a/src/activity-function-notation.xml
+++ b/src/activity-function-notation.xml
@@ -1732,9 +1732,8 @@
     </p>
 
     <exercise>
+      <title>Solving Graphically</title>
       <webwork>
-          <title>Solving Graphically</title>
-
             <pg-code>
                 $numZeros = 3;
                 $zeros = List(-4,-1,2);

--- a/src/activity-function-notation.xml
+++ b/src/activity-function-notation.xml
@@ -851,7 +851,7 @@
       and the bottom row is the output.
     </p>
 
-    <table>
+    <figure>
       <caption>Vertical Table</caption>
       <tabular>
         <col right="medium"/>
@@ -874,9 +874,9 @@
         </row>
       </tabular>
 
-    </table>
+    </figure>
 
-    <table>
+    <figure>
       <caption>Horizontal Table</caption>
       <tabular>
         <col right="medium"/>
@@ -897,7 +897,7 @@
         </row>
       </tabular>
 
-    </table>
+    </figure>
 
     <exercise>
       <title>Determine if the relation in each table is a function or not</title>

--- a/src/activity-function-notation.xml
+++ b/src/activity-function-notation.xml
@@ -151,9 +151,7 @@
               is the output.
             </p>
 
-            <sidebyside>
-              <image pg-name="$gr[0]" />
-            </sidebyside>
+            <image pg-name="$gr[0]"/>
 
             <p>
               Use the graph to estimate your answers below:
@@ -215,9 +213,7 @@
               So <m>77 \text{degrees Fahrenheit} \approx25 \text{degrees Celsius}</m>.
             </p>
 
-            <sidebyside>
-              <image pg-name="$gr[1]" />
-            </sidebyside>
+            <image pg-name="$gr[1]"/>
 
             <p>
               A similar process in reverse is used to determine the Fahrenheit temperature equivalent of <m>-22</m> degrees Celsius.

--- a/src/activity-function-notation.xml
+++ b/src/activity-function-notation.xml
@@ -1263,8 +1263,6 @@
                 $miles = PopUp(["?", "feet", "miles", "light years", "meters"], "miles");
             </pg-code>
           <statement>
-            <sidebyside>
-
               <tabular top="medium" bottom="medium" left="medium" right="medium">
                 <col halign="center"/>
                 <col halign="center"/>
@@ -1297,8 +1295,6 @@
                   <cell><m>47</m></cell>
                 </row>
               </tabular>
-
-            </sidebyside>
 
             <p>
               Remember that in a vertical table,

--- a/src/activity-inverse.xml
+++ b/src/activity-inverse.xml
@@ -957,8 +957,6 @@
             but its inverse is <em>not</em> a function.
           </p>
 
-          <sidebyside>
-
             <tabular top="major" halign="center">
               <col halign="left" />
               <col />
@@ -983,8 +981,6 @@
                 <cell><m>7</m></cell>
               </row>
             </tabular>
-
-          </sidebyside>
 
           <p>
             There is an output value of <m>f</m> that is causing the inverse <m>f^{-1}</m> to
@@ -1064,8 +1060,6 @@
             but the function <m>g</m> is <em>non-invertible</em>.
           </p>
 
-          <sidebyside>
-
             <tabular top="major" halign="center" left="major">
               <col halign="left"/>
               <col right="medium" />
@@ -1106,8 +1100,6 @@
                 <cell><m>5</m></cell>
               </row>
             </tabular>
-
-          </sidebyside>
 
           <p>
             In the last problem,

--- a/src/activity-inverse.xml
+++ b/src/activity-inverse.xml
@@ -322,7 +322,7 @@
     See the next exercise.
   </p>
 
-  <todo>Should we make this a scaffolded problem?</todo>
+  <!-- TODO: Should we make this a scaffolded problem? -->
 
   <exercise>
     <webwork>

--- a/src/activity-inverse.xml
+++ b/src/activity-inverse.xml
@@ -34,7 +34,6 @@
 
   <exercise>
     <webwork>
-        <setup>
 
         <pg-code>
           $increase=random(3,7,1);
@@ -43,7 +42,6 @@
           $x=random(10,20,1);
           $y=Compute("$x+$increase");
         </pg-code>
-        </setup>
         <statement>
           <p>
             The function <m>f(x) = <var name="$f" /></m> can be described as the function which
@@ -151,13 +149,11 @@
 
   <exercise>
     <webwork>
-        <setup>
 
         <pg-code>
           @x=map{$_+2}NchooseK(8,4);
           @y=map{$_+12}NchooseK(8,4);
         </pg-code>
-        </setup>
         <statement>
           <p>
             If <m>f</m> and <m>g</m> are functions,
@@ -259,7 +255,6 @@
 
   <exercise>
     <webwork>
-      <setup>
         <pg-code>
           Context()->variables->are(a=>'Real', b=>'Real', c=>'Real', d=>'Real');
           $num=random(3,20,1);
@@ -267,7 +262,6 @@
           list_random(@letters);  
           $var=$letters[random($total)];
         </pg-code>
-      </setup>
       <statement>
         <p>
           Let <m>w</m> be a function and <m>w^{-1}</m> be its inverse.
@@ -332,13 +326,11 @@
 
   <exercise>
     <webwork>
-        <setup>
 
         <pg-code>
           @x=map{$_+1}NchooseK(4,2);
           @fInverse=map{(12-2*$_)/($_)}@x;
         </pg-code>
-        </setup>
         <statement>
           <p>
             We already know that <m>f^{-1}</m> undoes the action of <m>f</m>:
@@ -428,13 +420,11 @@
 
   <exercise>
     <webwork>
-        <setup>
 
         <pg-code>
           $interpretF=PopUp(["?",'If the area is 1500 square feet, then the price is 4600 dollars.','If the area is 4600 square feet, then the price is 1500 dollars.'],1);
           $interpretFInverse=PopUp(["?",'If the price is 3500 dollars, then the area is 1000 square feet.','If the price is 1000 dollars, then the area is 3500 square feet.'],1);
         </pg-code>
-        </setup>
         <statement>
           <p>
             Let <m>f</m> be the function which will find the cost <m>C</m>,
@@ -508,7 +498,6 @@
 
   <exercise>
     <webwork>
-        <setup>
 
         <pg-code>
           Context('Numeric');
@@ -523,7 +512,6 @@
               displayLabels => 0
           );
         </pg-code>
-        </setup>
         <statement>
           <p>
             Let <m>S = G(t)</m> be a function which will calculate the salary <m>S</m>,
@@ -638,14 +626,12 @@
 
   <exercise>
     <webwork>
-        <setup>
 
         <pg-code>
           $m=random(6,10,1);
           $b=random(1,5,1);
           $fInverse=Compute("(x+$b)/($m)");
         </pg-code>
-        </setup>
         <statement>
           <p>
             In this exercise,
@@ -707,12 +693,10 @@
 
   <exercise>
     <webwork>
-        <setup>
 
         <pg-code>
           $hInverse=Compute("5*x/7-3");
         </pg-code>
-        </setup>
         <statement>
           <p>
             Let
@@ -765,14 +749,12 @@
 
   <exercise>
     <webwork>
-        <setup>
 
         <pg-code>
           $point1=PopUp(["?",'(0, 3)','(3, 0)'],2);
           $point2=PopUp(["?",'(-1, -2)','(-2, -1)'],1);
           $correct=PopUp(["?","Yes","No"],1);
         </pg-code>
-        </setup>
         <statement>
           <p>
             The graph below shows the linear function
@@ -869,7 +851,6 @@
 
   <exercise>
     <webwork>
-        <setup>
 
         <pg-code>
           $interpretation=RadioButtons(
@@ -878,7 +859,6 @@
               displayLabels => 0
           );
         </pg-code>
-        </setup>
         <statement>
           <p>
             The next graph shows the dashed line <m>y = x</m>.
@@ -965,14 +945,12 @@
 
   <exercise>
     <webwork>
-        <setup>
 
         <pg-code>
           $a=Real(7);
           $why=PopUp(["?","f should never have that output","f had that output twice"],2);
 
         </pg-code>
-        </setup>
         <statement>
           <p>
             The following table <em>is</em> a function,
@@ -1074,13 +1052,11 @@
 
   <exercise>
     <webwork>
-        <setup>
 
         <pg-code>
           $non=PopUp(["?","At least one output value is repeated","No output values are repeated"],1);
           $inv=PopUp(["?","At least one output value is repeated","No output values are repeated"],2);
         </pg-code>
-        </setup>
         <statement>
           <p>
             Below are tables for two functions, <m>f</m> and <m>g</m>.
@@ -1183,13 +1159,11 @@
 
   <exercise>
     <webwork>
-        <setup>
 
         <pg-code>
           $non=PopUp(['?','A horizontal line never intersects the graph more than once.','A horizontal line may intersect the graph more than once.'],2);
           $inv=PopUp(['?','A horizontal line never intersects the graph more than once.','A horizontal line may intersect the graph more than once.'],1);
         </pg-code>
-        </setup>
         <statement>
           <p>
             The graph of a non-invertible function <m>f</m> is shown below.

--- a/src/activity-inverse.xml
+++ b/src/activity-inverse.xml
@@ -259,7 +259,7 @@
           Context()->variables->are(a=>'Real', b=>'Real', c=>'Real', d=>'Real');
           $num=random(3,20,1);
           @letters = ('a'..'d');
-          list_random(@letters);  
+          list_random(@letters);
           $var=$letters[random($total)];
         </pg-code>
       <statement>

--- a/src/activity-logarithmic-functions.xml
+++ b/src/activity-logarithmic-functions.xml
@@ -260,8 +260,6 @@
               Use the equation <m>y=<var name="$a" />^x</m> to complete the table.
             </p>
 
-            <sidebyside>
-
               <tabular top="medium" bottom="medium" left="medium" right="medium">
                 <col halign="center"/>
                 <col halign="center"/>
@@ -291,10 +289,8 @@
                 </row>
               </tabular>
 
-            </sidebyside>
           </statement>
           <solution>
-            <sidebyside>
 
               <tabular top="medium" bottom="medium" left="medium" right="medium">
                 <col halign="center"/>
@@ -324,8 +320,6 @@
                   <cell><var name="$tabout[4]" /></cell>
                 </row>
               </tabular>
-
-            </sidebyside>
           </solution>
       </webwork>
     </exercise>
@@ -370,8 +364,6 @@
               To that end, you make the table:
             </p>
 
-            <sidebyside>
-
               <tabular top="medium" bottom="medium" left="medium" right="medium">
                 <col halign="center"/>
                 <col halign="center"/>
@@ -400,8 +392,6 @@
                   <cell><m><var name="$tabout[4]"/></m></cell>
                 </row>
               </tabular>
-
-            </sidebyside>
 
             <p>
               The result we want,
@@ -623,8 +613,6 @@
       which used base <m>10</m>, looks when written in both English and Math.
     </p>
 
-    <sidebyside>
-
       <tabular>
         <col right="medium"/>
         <col right="medium" halign="center"/>
@@ -645,8 +633,6 @@
           <cell>log base <m>10</m> of <m>0.6</m></cell>
         </row>
       </tabular>
-
-    </sidebyside>
 
     <p>
       For example, <m>\log_{10}(100)</m> means
@@ -1331,8 +1317,6 @@
               The answer to this question goes in the output box.
             </p>
 
-            <sidebyside>
-
               <tabular top="medium" bottom="medium" left="medium" right="medium">
                 <col halign="center"/>
                 <col halign="center"/>
@@ -1370,8 +1354,6 @@
                 </row>
               </tabular>
 
-            </sidebyside>
-
             <p>
               [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/mJYWSCfb/width/431/height/300/border/888888/smb/false/stb/false/stbh/false/ai/false/asb/false/sri/false/rc/false/ld/false/sdz/false/ctl/false" width="431px" height="300px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
             </p>
@@ -1408,8 +1390,6 @@
               Remember negative exponents mean <q>reciprocal</q>.
             </p>
 
-            <sidebyside>
-
               <tabular top="medium" bottom="medium" left="medium" right="medium">
                 <col halign="center"/>
                 <col halign="center"/>
@@ -1438,8 +1418,6 @@
                   <cell><var name="-1" width="5" /></cell>
                 </row>
               </tabular>
-
-            </sidebyside>
 
             <p>
               [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/MrhswJHV/width/431/height/360/border/888888/smb/false/stb/false/stbh/false/ai/false/asb/false/sri/false/rc/false/ld/false/sdz/false/ctl/false" width="431px" height="360px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*

--- a/src/activity-logarithmic-functions.xml
+++ b/src/activity-logarithmic-functions.xml
@@ -67,7 +67,6 @@
 
     <exercise>
       <webwork seed="1">
-          <setup>
 
             <pg-code>
                 $a[0]=random(2,4,1);
@@ -110,7 +109,6 @@
                 if($envir{problemSeed}==1){$a[6]=2;};
                 $answer[6]=Compute("DNE");
             </pg-code>
-          </setup>
           <statement>
             <p>
               <ol label="a">
@@ -251,14 +249,12 @@
     <exercise>
       <title>Powers of <m>10</m></title>
       <webwork seed="1">
-          <setup>
 
             <pg-code>
                 $a=list_random(2,4,5,10,20);
                 if($envir{problemSeed}==1){$a=10;};
                 @tabout=map{$a**$_}(-2..2);
             </pg-code>
-          </setup>
           <statement>
             <p>
               Use the equation <m>y=<var name="$a" />^x</m> to complete the table.
@@ -357,7 +353,6 @@
     <exercise>
       <title>Guess-and-Check</title>
       <webwork seed="1">
-          <setup>
 
             <pg-code>
                 $a=list_random(2,4,5,10,20);
@@ -369,7 +364,6 @@
                 $low=$a**$lowx;
                 $high=$a**$highx;
             </pg-code>
-          </setup>
           <statement>
             <p>
               We wish to solve the equation <m><var name="$a"/>^x=<var name="$b"/></m>.
@@ -500,7 +494,6 @@
       </introduction>
 
       <webwork seed="1">
-          <setup>
 
             <pg-code>
                 $a=10;
@@ -510,7 +503,6 @@
                 $answer=Real(ln($b)/ln(10));
                 $answer2=Real(ln($c)/ln(10));
             </pg-code>
-          </setup>
           <statement>
             <p>
               We wish to solve the equation <m><var name="$a"/>^x=<var name="$b"/></m>.
@@ -663,7 +655,6 @@
 
     <exercise>
       <webwork seed="1">
-          <setup>
 
             <pg-code>
                 Context("LimitedNumeric");
@@ -671,7 +662,6 @@
                 if($envir{problemSeed}==1){$b=2};
                 $c=10**$b;
             </pg-code>
-          </setup>
           <statement>
             <p>
               The power of <m>10</m> that gives you <m>100</m> is written in math as:
@@ -730,7 +720,6 @@
 
     <exercise>
       <webwork seed="1">
-          <setup>
 
             <pg-code>
                 do{@b=map{$_+2}NchooseK(7,4);
@@ -741,7 +730,6 @@
                 Context()->strings->add(logarithm=>{alias=>'log'});
                 $log=String('log');
             </pg-code>
-          </setup>
           <statement>
             <p>
               How would you say each expression below using logarithms?
@@ -825,7 +813,6 @@
 
     <exercise>
       <webwork seed="1">
-          <setup>
 
             <pg-code>
                 Parser::Number::NoDecimals();
@@ -837,7 +824,6 @@
                 $answer[2]=Formula("ln($c[2])");
                 $answer[3]=Formula("ln($c[3])");
             </pg-code>
-          </setup>
           <statement>
             <p>
               Write the following English statements using the equivalent Math statements using logarithms.
@@ -921,7 +907,6 @@
 
     <exercise>
       <webwork seed="1">
-          <setup>
 
             <pg-code>
                 @b=map{$_+2}NchooseK(7,2);
@@ -930,7 +915,6 @@
                 $c[1]=Fraction(1,$b[1]**random(2,4,1));
                 if($envir{problemSeed}==1){$b[0]=3;$c[0]=9;$b[1]=5;$c[1]=Fraction(1,25);};
             </pg-code>
-          </setup>
           <statement>
             <p>
               Translate each math expression below into its meaning in English.
@@ -986,7 +970,6 @@
 
     <exercise>
       <webwork seed="1">
-          <setup>
 
             <pg-code>
                 $b[0]=10;
@@ -997,7 +980,6 @@
                 if($envir{problemSeed}==1){@b=(10,5,2,2);@c=(120,15,18,0.7)};
                 for my $i(0..3){$low[$i]=floor(ln($c[$i])/ln($b[$i]));$high[$i]=$low[$i]+1;};
             </pg-code>
-          </setup>
           <statement>
             <p>
               For each logarithm expression below,
@@ -1085,14 +1067,12 @@
 
     <exercise>
       <webwork seed="1">
-          <setup>
 
             <pg-code>
                 $b=10;
                 $c=-$b**random(-2,4,1);
                 if($envir{problemSeed}==1){$c=-100;};
             </pg-code>
-          </setup>
           <statement>
             <p>
               Translate the math expression below into what it would mean in English
@@ -1135,14 +1115,12 @@
 
     <exercise>
       <webwork seed="1">
-          <setup>
 
             <pg-code>
                 $b=10;
                 $c=-$b**random(-2,4,1);
                 if($envir{problemSeed}==1){$c=0;};
             </pg-code>
-          </setup>
           <statement>
             <p>
               Translate the math expression below into what it would mean in English
@@ -1187,13 +1165,11 @@
 
     <exercise>
       <webwork seed="1">
-          <setup>
 
             <pg-code>
                 Context("InequalitySetBuilder");
                 $domain=Compute("(0,inf)");
             </pg-code>
-          </setup>
           <statement>
             <p>
               Use an inequality or an interval to complete the statement below:
@@ -1488,7 +1464,6 @@
     <exercise>
       <title>Comparing Graphs of Various Bases</title>
       <webwork>
-          <setup>
 
             <pg-code>
                 Context('Numeric');
@@ -1497,7 +1472,6 @@
                 1, labels => ["log(x)","log2(x)"],displayLabels => 0
                 );
             </pg-code>
-          </setup>
           <statement>
             <p>
               [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/RdRRdBJM/width/431/height/360/border/888888/smb/false/stb/false/stbh/false/ai/false/asb/false/sri/false/rc/false/ld/false/sdz/false/ctl/false" width="431px" height="360px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
@@ -1623,7 +1597,6 @@
 
       <exercise>
         <webwork seed="1">
-            <setup>
 
             <pg-code>
                 Context()->variables->are(x=>'Real',y=>'Real',b=>'Real');
@@ -1634,7 +1607,6 @@
                 $exp2=Formula("2^{-1}");
                 $exp3=Formula("2^{0}");
             </pg-code>
-            </setup>
             <statement>
               <p>
                 An exponential equation
@@ -1707,7 +1679,6 @@
 
       <exercise>
         <webwork seed="1">
-            <setup>
 
             <pg-code>
                 Context()->operators->set(
@@ -1740,7 +1711,6 @@
                 $by=Real($b**$y);
                 $bz=Real($b**$z);
             </pg-code>
-            </setup>
             <statement>
               <p>
                 Simplify and rewrite the product <m><var name="$b" />^<var name="$x" />\cdot <var name="$b" />^<var name="$y" /></m> as one exponential expression.
@@ -1791,12 +1761,10 @@
 
       <exercise>
         <webwork seed="1">
-            <setup>
 
             <pg-code>
                 $seven=7;
             </pg-code>
-            </setup>
             <statement>
               <p>
                 What power of <m>2</m> gives you <m>128</m>?
@@ -1940,7 +1908,6 @@
 
       <exercise>
         <webwork>
-            <setup>
 
             <pg-code>
                 Context("LimitedRadical");
@@ -1948,7 +1915,6 @@
                 $c=4;
                 $N=Formula("x");
             </pg-code>
-            </setup>
             <statement>
               <p>
                 Multiplication is shorthand for repeated addition.
@@ -2010,7 +1976,6 @@
 
       <exercise>
         <webwork>
-            <setup>
 
             <pg-code>
                 Context()->variables->add(A=>'Real', B=>'Real');
@@ -2022,7 +1987,6 @@
                 $term3=Compute("-log(B)");
                 $N=Formula("x");
             </pg-code>
-            </setup>
             <statement>
               <p>
                 Consider the expression <m>\log\mathopen{}\left(\frac{A}{B}\right)\mathclose{}</m>

--- a/src/activity-periodic-functions.xml
+++ b/src/activity-periodic-functions.xml
@@ -607,8 +607,6 @@
               Complete the table of values below for the function <m>f</m>.
             </p>
 
-            <sidebyside>
-
               <tabular top="major" halign="center">
                 <col halign="left" />
                 <col />
@@ -637,12 +635,8 @@
                   <cell><var name="$h[4]" width="10" /></cell>
                 </row>
               </tabular>
-
-            </sidebyside>
           </statement>
           <solution>
-            <sidebyside>
-
               <tabular top="major" halign="center">
                 <col halign="left" />
                 <col />
@@ -671,8 +665,6 @@
                   <cell><m>10</m></cell>
                 </row>
               </tabular>
-
-            </sidebyside>
           </solution>
           </stage>
           <stage>
@@ -681,8 +673,6 @@
               You found the heights in the following table:
             </p>
 
-            <sidebyside>
-
               <tabular top="major" halign="center">
                 <col halign="left" />
                 <col />
@@ -711,8 +701,6 @@
                   <cell><m>10</m></cell>
                 </row>
               </tabular>
-
-            </sidebyside>
 
             <p>
               In the graph below,

--- a/src/activity-periodic-functions.xml
+++ b/src/activity-periodic-functions.xml
@@ -22,7 +22,6 @@
 
     <exercise>
       <webwork>
-          <setup>
 
             <pg-code>
               $timeToCharge=Real(6);
@@ -31,7 +30,6 @@
               );
               $period=Real(24);
             </pg-code>
-          </setup>
           <statement>
             <p>
               The following graph shows the &#37;
@@ -130,7 +128,6 @@
 
     <exercise>
       <webwork>
-          <setup>
 
             <pg-code>
               $per=Real(4);
@@ -168,7 +165,6 @@
               );
               add_functions($gr2, "2*sin(2*pi/3*x)-2*cos(2*pi/1.5*x)-2 for x in &lt;-2,12&gt; using color:red and weight:2");
             </pg-code>
-          </setup>
           <statement>
             <p>
               The period of each function below is a whole number.
@@ -233,14 +229,12 @@
 
     <exercise>
       <webwork>
-          <setup>
 
             <pg-code>
               $vertStretch=PopUp(["?","Changing the radius of the wheel","Changing the platform height","Changing the period"],"Changing the radius of the wheel");
               $vertShift=PopUp(["?","Changing the radius of the wheel","Changing the platform height","Changing the period"],"Changing the platform height");
               $horizontalStretch=PopUp(["?","Changing the radius of the wheel","Changing the platform height","Changing the period"],"Changing the period");
             </pg-code>
-          </setup>
           <statement>
             <p>
               Suppose a person boards at the bottom of a Ferris Wheel and rides around for <m>35</m> seconds.
@@ -405,7 +399,6 @@
 
     <exercise>
       <webwork>
-          <setup>
 
             <pg-code>
               $period=Real(4);
@@ -418,7 +411,6 @@
               );
               add_functions($gr, "-1.5*cos(2*pi/4*x)-3.5 for x in &lt;-2,12&gt; using color:red and weight:2");
             </pg-code>
-          </setup>
           <statement>
             <sidebyside>
               <image pg-name="$gr" />
@@ -586,7 +578,6 @@
 
     <exercise>
       <webwork>
-          <setup>
 
             <pg-code>
               $amplitude=Real(30);
@@ -603,7 +594,6 @@
               parser::Assignment->Allow;
               $midline=Formula("y=40");
             </pg-code>
-          </setup>
           <stage>
           <statement>
             <p>
@@ -805,7 +795,6 @@
 
     <exercise>
       <webwork>
-          <setup>
 
             <pg-code>
               $radius=Real(60);
@@ -818,7 +807,6 @@
               );
               add_functions($gr, "-60*cos(2*pi/15*x)+80 for x in &lt;0,45&gt; using color:red and weight:2");
             </pg-code>
-          </setup>
           <statement>
             <p>
               A person boards a Ferris Wheel at the <m>6</m>

--- a/src/activity-periodic-functions.xml
+++ b/src/activity-periodic-functions.xml
@@ -171,25 +171,19 @@
               Find the period of each function.
             </p>
 
-            <sidebyside>
-              <image pg-name="$gr" />
-            </sidebyside>
+            <image pg-name="$gr"/>
 
             <p>
               Period = <var name="$per" width="10" />
             </p>
 
-            <sidebyside>
-              <image pg-name="$gr1" />
-            </sidebyside>
+            <image pg-name="$gr1"/>
 
             <p>
               Period = <var name="$per1" width="10" />
             </p>
 
-            <sidebyside>
-              <image pg-name="$gr2" />
-            </sidebyside>
+            <image pg-name="$gr2"/>
 
             <p>
               Period = <var name="$per2" width="10" />
@@ -412,9 +406,7 @@
               add_functions($gr, "-1.5*cos(2*pi/4*x)-3.5 for x in &lt;-2,12&gt; using color:red and weight:2");
             </pg-code>
           <statement>
-            <sidebyside>
-              <image pg-name="$gr" />
-            </sidebyside>
+            <image pg-name="$gr"/>
 
             <p>
               The graph above shows a periodic function.
@@ -822,9 +814,7 @@
               Use the graph to help answer the questions that follow.
             </p>
 
-            <sidebyside>
-              <image pg-name="$gr" />
-            </sidebyside>
+            <image pg-name="$gr"/>
 
             <p>
               <ol label="a">

--- a/src/activity-piecewise.xml
+++ b/src/activity-piecewise.xml
@@ -75,7 +75,6 @@
 
     <exercise>
       <webwork>
-          <setup>
 
          <pg-code>
           $A = RadioButtons(
@@ -105,7 +104,6 @@
               $answer2 = Compute("-3&lt;=x&lt;=2");
               $answer3 = Compute("2&lt;x&lt;=8");
          </pg-code>
-          </setup>
           <stage>
           <statement>
             <p>
@@ -309,7 +307,6 @@
 
     <exercise>
       <webwork>
-          <setup>
 
           <pg-code>
             Context()->variables->are(x=>'Real',y=>'Real');
@@ -328,7 +325,6 @@
               $answer2 = Compute("-3&lt;=x&lt;=2");
               $answer3 = Compute("2&lt;x&lt;=8");
           </pg-code>
-          </setup>
           <stage>
           <statement>
             <p>
@@ -577,12 +573,10 @@
 
     <exercise>
       <webwork>
-          <setup>
 
             <pg-code>
               $answer1 = Real(1);
             </pg-code>
-          </setup>
           <statement>
             <p>
               Use the axes below to plot three points for each function on its given domain.

--- a/src/activity-piecewise.xml
+++ b/src/activity-piecewise.xml
@@ -390,8 +390,6 @@
               Write the three formulas below next to their corresponding domains.
             </p>
 
-            <sidebyside>
-
               <tabular>
                 <col halign="center"/>
                 <col halign="center"/>
@@ -413,7 +411,6 @@
                 </row>
               </tabular>
 
-            </sidebyside>
           </statement>
           </stage>
           <stage>

--- a/src/activity-polynomials.xml
+++ b/src/activity-polynomials.xml
@@ -764,8 +764,6 @@
               </me>
             </p>
 
-            <sidebyside>
-
               <tabular top="major" halign="center">
                 <col halign="left" />
                 <col halign="left" />
@@ -794,8 +792,6 @@
                   <cell><m><var name="$y[4]" /></m></cell>
                 </row>
               </tabular>
-
-            </sidebyside>
 
             <p>
               What appears to be the horizontal asymptote of <m>f(x)</m>?

--- a/src/activity-polynomials.xml
+++ b/src/activity-polynomials.xml
@@ -468,21 +468,13 @@
               choose which option below could be the graph of <m>p(x)</m>.
             </p>
 
-            <sidebyside widths="40%">
-              <image pg-name="$gr[0]" />
-            </sidebyside>
+            <image pg-name="$gr[0]" width="40%"/>
 
-            <sidebyside widths="40%">
-              <image pg-name="$gr[1]" />
-            </sidebyside>
+            <image pg-name="$gr[1]" width="40%"/>
 
-            <sidebyside widths="40%">
-              <image pg-name="$gr[2]" />
-            </sidebyside>
+            <image pg-name="$gr[2]" width="40%"/>
 
-            <sidebyside widths="40%">
-              <image pg-name="$gr[3]" />
-            </sidebyside>
+            <image pg-name="$gr[3]" width="40%"/>
 
             <p>
               Answer:
@@ -1279,9 +1271,7 @@
               Your goal is to write its formula.
             </p>
 
-            <sidebyside>
-              <image pg-name="$gr" />
-            </sidebyside>
+            <image pg-name="$gr"/>
 
             <p>
               Complete the statement below with a number:
@@ -1370,9 +1360,7 @@
               Answer the following questions in order to write the formula for <m>f(x)</m>.
             </p>
 
-            <sidebyside>
-              <image pg-name="$gr" />
-            </sidebyside>
+            <image pg-name="$gr"/>
 
             <p>
               <ol label="a">
@@ -1590,17 +1578,11 @@
               Use the input value <m>x = 2</m> to decide which of the graphs matches our formula.
             </p>
 
-            <sidebyside widths="40%">
-              <image pg-name="$gr[0]" />
-            </sidebyside>
+            <image pg-name="$gr[0]" width="40%"/>
 
-            <sidebyside widths="40%">
-              <image pg-name="$gr[1]" />
-            </sidebyside>
+            <image pg-name="$gr[1]" width="40%"/>
 
-            <sidebyside widths="40%">
-              <image pg-name="$gr[2]" />
-            </sidebyside>
+            <image pg-name="$gr[2]" width="40%"/>
 
             <p>
               Answer:
@@ -1653,9 +1635,7 @@
               </me>.
             </p>
 
-            <sidebyside>
-              <image pg-name="$gr[1]" />
-            </sidebyside>
+            <image pg-name="$gr[1]"/>
 
             <p>
               What is the formula for this graph?
@@ -1726,9 +1706,7 @@
               for some value <m>k</m>.
             </p>
 
-            <sidebyside>
-              <image pg-name="$gr[2]" />
-            </sidebyside>
+            <image pg-name="$gr[2]"/>
 
             <p>
               We can use the fact that this graph passes through the point <m>(2, 3)</m> to solve for the value <m>k</m>.
@@ -1789,9 +1767,7 @@
               Answer the questions that follow in order to write the formula for <m>f(x)</m>.
             </p>
 
-            <sidebyside>
-              <image pg-name="$gr" />
-            </sidebyside>
+            <image pg-name="$gr"/>
 
             <p>
               Begin the formula with just the linear factors we need in order to have the correct <m>x</m>-intercepts.
@@ -2138,9 +2114,7 @@
               The graph below shows a <m>5^{\rm{th}}</m> degree polynomial <m>y = f(x)</m>.
             </p>
 
-            <sidebyside>
-              <image pg-name="$gr" />
-            </sidebyside>
+            <image pg-name="$gr"/>
 
             <p>
               Write a formula for <m>f(x)</m> below,

--- a/src/activity-polynomials.xml
+++ b/src/activity-polynomials.xml
@@ -92,7 +92,6 @@
 
     <exercise>
       <webwork>
-          <setup>
 
           <pg-code>
             $true=PopUp(
@@ -102,7 +101,6 @@
             ["?","True","False"],"False"
             );
           </pg-code>
-          </setup>
           <statement>
             <p>
               For each statement below, decide if it is True or False.
@@ -170,7 +168,6 @@
 
     <exercise>
       <webwork>
-          <setup>
 
           <pg-code>
             $m=random(3,9,1);
@@ -181,7 +178,6 @@
             Context("Fraction");
             $root=Fraction(-$b,$m);
           </pg-code>
-          </setup>
           <statement>
             <p>
               <ol label="a">
@@ -220,7 +216,6 @@
     <exercise>
       <webwork>
           <pg-macros><macro-file>contextLimitedPolynomial.pl</macro-file></pg-macros>
-          <setup>
 
           <pg-code>
             $degree1=Real(1);
@@ -228,7 +223,6 @@
             Context("LimitedPolynomial");
             $formula=Formula("x^2-x-2");
           </pg-code>
-          </setup>
           <statement>
             <p>
               Use the checkboxes to graph the functions:
@@ -327,12 +321,10 @@
 
     <exercise>
       <webwork>
-          <setup>
 
           <pg-code>
             $rootsWhere=PopUp(["?","It has both roots of the linear functions.","It has different roots than the linear functions.","Roots? There are no roots."],1);
           </pg-code>
-          </setup>
           <statement>
             <p>
               [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/ZQ4DEqee/width/432/height/373/border/888888/sdz/false/" width="432px" height="373px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
@@ -370,7 +362,6 @@
 
     <exercise>
       <webwork>
-          <setup>
 
           <pg-code>
             $variable=PopUp(["?","x","y"],"x");
@@ -379,7 +370,6 @@
             $root0=Real(0);
             $rootsAll=PopUp(["?","All the roots of f, g and h","None of the roots of f, g or h","Roots? There are no roots!"],1);
           </pg-code>
-          </setup>
           <statement>
             <p>
               Use the checkboxes to graph the functions:
@@ -431,7 +421,6 @@
 
     <exercise>
       <webwork>
-          <setup>
 
           <pg-code>
             $graph=PopUp(["?","Graph A","Graph B","Graph C","Graph D"],4);
@@ -468,7 +457,6 @@
             add_functions($gr[3], "(x+1)*(x-2)*(x-3) for x in &lt;-2,5&gt; using color:red and weight:2");
             $gr[3] -> lb(new Label ( 4,-12,'Graph D','red','right','bottom'));
           </pg-code>
-          </setup>
           <statement>
             <p>
               Let <m>p(x) = (x-2)(x+1)(2x-6)</m>.
@@ -533,7 +521,6 @@
 
     <exercise>
       <webwork>
-          <setup>
 
           <pg-code>
             $c=4;
@@ -543,7 +530,6 @@
             @c=map{-1*$_}@b;
             $roots=PopUp(["?","$b[0], $c[1] and $b[2]","$b[0], $b[1] and $b[2]","$c[0], $b[1] and $c[2]"],"$b[0], $b[1] and $b[2]");
           </pg-code>
-          </setup>
           <statement>
             <p>
               Let <m>m(x) = (<var name="$c" />x - <var name="$a[0]" />)(x + <var name="$a[1]" />)(x - <var name="$a[2]" />)</m>.
@@ -596,12 +582,10 @@
 
     <exercise>
       <webwork>
-          <setup>
 
           <pg-code>
             $didItGraph=PopUp(["?","yes","no"],"yes");
           </pg-code>
-          </setup>
           <statement>
             <p>
               Move the points to the <m>x</m>-intercepts of the graph:
@@ -660,14 +644,12 @@
 
     <exercise>
       <webwork>
-          <setup>
 
           <pg-code>
             $rootsN=PopUp(["?","2","N"],"N");
             $linearFactors=PopUp(["?","variables","linear factors","terms"],"linear factors");
             $intercepts=PopUp(["?","(a,0)","(0,a)","(-a,0)","(0,-a)"],"(a,0)");
           </pg-code>
-          </setup>
           <statement>
             <p>
               Complete each statement below:
@@ -771,7 +753,6 @@
 
     <exercise>
       <webwork>
-          <setup>
 
           <pg-code>
             @x=(1, 10, 100, 1000, 10000);
@@ -783,7 +764,6 @@
             Context("Fraction");
             $value=Fraction($a,$c);
           </pg-code>
-          </setup>
           <statement>
             <p>
               The table below shows values of the function:
@@ -910,7 +890,6 @@
 
     <exercise>
       <webwork>
-          <setup>
 
           <pg-code>
             $compare=PopUp(["?","very different","very similar"],"very similar");
@@ -918,7 +897,6 @@
             $power=PopUp(["?","x^2","x^3"],"x^3");
             $term=Compute("x^3");
           </pg-code>
-          </setup>
           <statement>
             <p>
               The graph below shows:
@@ -985,12 +963,10 @@
 <!-- The graphs of x^3 and x^5 are messed up in the next problem...it was never like this before -->
     <exercise>
       <webwork>
-          <setup>
 
           <pg-code>
             $function=PopUp(["?","x^2","x^3","x^4","x^5"],"x^4");
           </pg-code>
-          </setup>
           <statement>
             <p>
               There is a lot going on in the following graph.
@@ -1100,7 +1076,6 @@
 
     <exercise>
       <webwork>
-          <setup>
 
           <pg-code>
             @a=map{2+$_}NchooseK(15,9);
@@ -1110,7 +1085,6 @@
             $vars4=PopUp(["?","x^2","x^3","x^4"],"x^4");
             $vars3=PopUp(["?","x^2","x^3","x^4"],"x^3");
           </pg-code>
-          </setup>
           <statement>
             <p>
               For each polynomial below, determine its leading term.
@@ -1209,14 +1183,12 @@
 
     <exercise>
       <webwork>
-          <setup>
 
           <pg-code>
             $left=PopUp(["?","Up","Down"],"Down");
             $right=PopUp(["?","Up","Down"],"Up");
             $end=PopUp(["?","x","x^2","x^3"],"x^3");
           </pg-code>
-          </setup>
           <statement>
             <p>
               This problem concerns the polynomial
@@ -1290,7 +1262,6 @@
 
     <exercise>
       <webwork>
-          <setup>
 
           <pg-code>
             $num=Real(3);
@@ -1302,7 +1273,6 @@
             );
             add_functions($gr, "(x+1)*(x-2)*(x-3) for x in &lt;-2,4&gt; using color:red and weight:2");
           </pg-code>
-          </setup>
           <statement>
             <p>
               A polynomial <m>y = f(x)</m> is graphed below.
@@ -1368,7 +1338,6 @@
 
     <exercise>
       <webwork>
-          <setup>
 
           <pg-code>
             @root=(-4,-1,2);
@@ -1395,7 +1364,6 @@
               return 1;
             });
           </pg-code>
-          </setup>
           <statement>
             <p>
               The graph below shows a polynomial <m>y = f(x)</m>.
@@ -1599,7 +1567,6 @@
 
     <exercise>
       <webwork>
-          <setup>
 
             <pg-code>
               $gr[0]=init_graph(-2,-7,7,7,axes=>[0,0],grid=>[9,14],size=>[240,240]);
@@ -1615,7 +1582,6 @@
               ["?","Graph A","Graph B","Graph C"],"Graph A"
               );
             </pg-code>
-          </setup>
           <statement>
             <p>
               Our guess for the formula,
@@ -1673,14 +1639,12 @@
 
     <exercise>
       <webwork>
-          <setup>
 
             <pg-code>
               $gr[1]=init_graph(-2,-7,7,7,axes=>[0,0],grid=>[9,14],size=>[400,400]);
               add_functions($gr[1], "2*(x-1)*(x-3)*(x-4) for x in &lt;-2,7&gt; using color:red and weight:2");
               $formula=Compute("2*(x-1)*(x-3)*(x-4)");
             </pg-code>
-          </setup>
           <statement>
             <p>
               The <m>2^{\rm{nd}}</m> graph is a vertical stretch of the function
@@ -1740,14 +1704,12 @@
 
     <exercise>
       <webwork>
-          <setup>
 
             <pg-code>
               $formula=Compute("1.5*(x-1)*(x-3)*(x-4)");
               $gr[2]=init_graph(-2,-7,7,7,axes=>[0,0],grid=>[9,14],size=>[400,400]);
               add_functions($gr[2], "1.5*(x-1)*(x-3)*(x-4) for x in &lt;-2,7&gt; using color:red and weight:2");
             </pg-code>
-          </setup>
           <statement>
             <p>
               Recall that a vertical stretch of a function occurs by multiplying the outside of the function by a constant value <m>k</m>:
@@ -1809,7 +1771,6 @@
 
     <exercise>
       <webwork>
-          <setup>
 
             <pg-code>
               $m=Real(0.25);
@@ -1822,7 +1783,6 @@
               $gr->stamps( closed_circle(1,-3,'blue') );
               $gr -> lb(new Label ( 1.1,-2.9,'(1, -3)','red','left','bottom'));
             </pg-code>
-          </setup>
           <statement>
             <p>
               The graph below shows a polynomial <m>y = f(x)</m>.
@@ -1947,7 +1907,6 @@
 
     <exercise>
       <webwork>
-          <setup>
 
             <pg-code>
             $variable=PopUp(["?","x","y"],"x");
@@ -1956,7 +1915,6 @@
             $horizontal=PopUp(["?","more horizontal","more vertical"],"more horizontal");
             $root=Real(1);
           </pg-code>
-          </setup>
           <statement>
             <p>
               The graph below shows the polynomial:
@@ -2029,7 +1987,6 @@
 
     <exercise>
       <webwork>
-          <setup>
 
           <pg-code>
             $bounces=PopUp(["?","crosses over","bounces off"],"bounces off");
@@ -2038,7 +1995,6 @@
             $crosses=PopUp(["?","crosses over","bounces off"],"crosses over");
             $horizontal=PopUp(["?","vertical","horizontal"],"horizontal");
           </pg-code>
-          </setup>
           <statement>
             <p>
               The graph below shows the polynomial:
@@ -2094,7 +2050,6 @@
 
     <exercise>
       <webwork>
-          <setup>
 
           <pg-code>
             $cross=PopUp(["?","graph bounces off of the x-axis","graph crosses over the x-axis"],2);
@@ -2102,7 +2057,6 @@
             $flat=PopUp(["?","graph is very curved","graph is nearly horizontal"],2);
             $curved=PopUp(["?","graph is very curved","graph is nearly horizontal"],1);
           </pg-code>
-          </setup>
           <statement>
             <p>
               Suppose a polynomial <m>g(x)</m> has roots <m>x = 3</m> and <m>x = 5</m>.
@@ -2171,7 +2125,6 @@
 
     <exercise>
       <webwork>
-          <setup>
 
           <pg-code>
             $formula=Compute("(x+2)(x-1)^2(x-3)^2");
@@ -2180,7 +2133,6 @@
             $gr->stamps( closed_circle(0,18,'blue') );
             $gr -> lb(new Label ( 0.2,20,'(0, 18)','red','left','bottom'));
           </pg-code>
-          </setup>
           <statement>
             <p>
               The graph below shows a <m>5^{\rm{th}}</m> degree polynomial <m>y = f(x)</m>.

--- a/src/activity-polynomials.xml
+++ b/src/activity-polynomials.xml
@@ -1179,7 +1179,7 @@
       </webwork>
     </exercise>
 
-    <todo>Geogebra graphs are allowing click-and-drag when they shouldn't be.</todo>
+    <!-- TODO: Geogebra graphs are allowing click-and-drag when they shouldn't be. -->
 
     <exercise>
       <webwork>
@@ -1903,7 +1903,7 @@
       you will explore these effects on the graph.
     </p>
 
-    <todo>Geogebra graphs are allowing click-and-drag when they shouldn't be.</todo>
+    <!-- TODO: Geogebra graphs are allowing click-and-drag when they shouldn't be. -->
 
     <exercise>
       <webwork>

--- a/src/activity-power-functions.xml
+++ b/src/activity-power-functions.xml
@@ -265,7 +265,7 @@
     Use this in the next exercise.
   </p>
 
-  <todo>At a future date, make this a sidebyside, once that is possible within a webwork</todo>
+  <!-- TODO: At a future date, make this a sidebyside, once that is possible within a webwork -->
 
   <exercise>
     <webwork>
@@ -650,7 +650,7 @@
     Use this in the next exercise.
   </p>
 
-  <todo>Use sidebyside when it is available</todo>
+  <!-- TODO: Use sidebyside when it is available -->
 
   <exercise>
     <webwork>

--- a/src/activity-power-functions.xml
+++ b/src/activity-power-functions.xml
@@ -224,9 +224,7 @@
             The graph below shows a power function.
           </p>
 
-          <sidebyside>
-            <image pg-name="$gr" />
-          </sidebyside>
+          <image pg-name="$gr"/>
 
           <p>
             What is a possible formula for this function?
@@ -288,21 +286,13 @@
 
           </pg-code>
         <statement>
-          <sidebyside widths="40%">
-            <image pg-name="$gr[0]" />
-          </sidebyside>
+          <image pg-name="$gr[0]" width="40%"/>
 
-          <sidebyside widths="40%">
-            <image pg-name="$gr[1]" />
-          </sidebyside>
+          <image pg-name="$gr[1]" width="40%"/>
 
-          <sidebyside widths="40%">
-            <image pg-name="$gr[2]" />
-          </sidebyside>
+          <image pg-name="$gr[2]" width="40%"/>
 
-          <sidebyside widths="40%">
-            <image pg-name="$gr[3]" />
-          </sidebyside>
+          <image pg-name="$gr[3]" width="40%"/>
 
           <p>
             The graphs show the following functions:
@@ -625,9 +615,7 @@
             The graph below shows a power function.
           </p>
 
-          <sidebyside>
-            <image pg-name="$gr" />
-          </sidebyside>
+          <image pg-name="$gr"/>
 
           <p>
             What is a possible formula for this function?
@@ -676,21 +664,13 @@
             add_functions($gr[3], "-x^(-3) for x in &lt;0.1,5> using color:blue and weight:2");
           </pg-code>
         <statement>
-          <sidebyside widths="40%">
-            <image pg-name="$gr[0]" />
-          </sidebyside>
+          <image pg-name="$gr[0]" width="40%"/>
 
-          <sidebyside widths="40%">
-            <image pg-name="$gr[1]" />
-          </sidebyside>
+          <image pg-name="$gr[1]" width="40%"/>
 
-          <sidebyside widths="40%">
-            <image pg-name="$gr[2]" />
-          </sidebyside>
+          <image pg-name="$gr[2]" width="40%"/>
 
-          <sidebyside widths="40%">
-            <image pg-name="$gr[3]" />
-          </sidebyside>
+          <image pg-name="$gr[3]" width="40%"/>
 
           <p>
             Select the graph for each formula:

--- a/src/activity-power-functions.xml
+++ b/src/activity-power-functions.xml
@@ -39,7 +39,6 @@
 
   <exercise>
     <webwork>
-        <setup>
 
           <pg-code>
             $positive=PopUp(
@@ -50,7 +49,6 @@
             );
             @ans=(16,16,32,-32);
           </pg-code>
-        </setup>
         <statement>
           <p>
             Recall that a positive integer exponent refers to
@@ -148,14 +146,12 @@
 
   <exercise>
     <webwork>
-        <setup>
 
           <pg-code>
             $evenExponent=PopUp(["?",'points upward on the right and downward on the left','points upward on the right and the left'],2);
             $oddExponent=PopUp(["?",'points upward on the right and downward on the left','points upward on the right and the left'],1);
             $commonPoints=PopUp(["?",'(-1,1)','(0,0) and (1,1)','(-1,-1) and (0,0) and (1,1)'],2);
           </pg-code>
-        </setup>
         <statement>
           <p>
             The graph below shows a power function of the form <m>f(x) = x^n</m>,
@@ -209,7 +205,6 @@
 
   <exercise>
     <webwork>
-        <setup>
 
           <pg-code>
             $formula=RadioButtons(
@@ -224,7 +219,6 @@
             );
             add_functions($gr, "x**5 for x in &lt;-1.5,1.5&gt; using color:red and weight:2");
           </pg-code>
-        </setup>
         <statement>
           <p>
             The graph below shows a power function.
@@ -275,7 +269,6 @@
 
   <exercise>
     <webwork>
-        <setup>
 
           <pg-code>
             $posEven=PopUp(["?","A","B","C","D"],"D");
@@ -294,7 +287,6 @@
             add_functions($gr[3], "x^4 for x in &lt;-5,5> using color:blue and weight:2");
 
           </pg-code>
-        </setup>
         <statement>
           <sidebyside widths="40%">
             <image pg-name="$gr[0]" />
@@ -439,7 +431,6 @@
 
   <exercise>
     <webwork>
-        <setup>
 
           <pg-code>
             $false=PopUp(
@@ -449,7 +440,6 @@
             ["?","True","False"],"True"
             );
           </pg-code>
-        </setup>
         <statement>
           <p>
             True or False:
@@ -533,14 +523,12 @@
 
   <exercise>
     <webwork>
-        <setup>
 
           <pg-code>
             $evenExponent=PopUp(["?",'points upward on both sides','points in opposite directions'],1);
             $oddExponent=PopUp(["?",'points upward on both sides','points in opposite directions'],2);
             $commonPoints=PopUp(["?",'(1,1)','(1,1) and (-1,1)'],1);
           </pg-code>
-        </setup>
         <statement>
           <p>
             The graph below shows a power function of the form <m>f(x) = x^n</m>,
@@ -617,7 +605,6 @@
 
   <exercise>
     <webwork>
-        <setup>
 
           <pg-code>
             $formula=RadioButtons(
@@ -633,7 +620,6 @@
             add_functions($gr, "x**(-4) for x in &lt;-6,-0.6&gt; using color:red and weight:2");
             add_functions($gr, "x**(-4) for x in &lt;0.6,6&gt; using color:red and weight:2");
           </pg-code>
-        </setup>
         <statement>
           <p>
             The graph below shows a power function.
@@ -668,7 +654,6 @@
 
   <exercise>
     <webwork>
-        <setup>
 
           <pg-code>
             $posEven=PopUp(["?","A","B","C","D"],"B");
@@ -690,7 +675,6 @@
             add_functions($gr[2], "x^(-4) for x in &lt;0.1,5> using color:blue and weight:2");
             add_functions($gr[3], "-x^(-3) for x in &lt;0.1,5> using color:blue and weight:2");
           </pg-code>
-        </setup>
         <statement>
           <sidebyside widths="40%">
             <image pg-name="$gr[0]" />
@@ -878,14 +862,12 @@
 
   <exercise>
     <webwork>
-        <setup>
 
           <pg-code>
             $evenExponent=PopUp(["?",'all real numbers',"x greater than or equal to 0"],2);
             $oddExponent=PopUp(["?",'all real numbers',"x greater than or equal to 0"],1);
             $commonPoints=PopUp(["?",'(-1,-1) and (0,0)','(0,0) and (1,1)'],2);
           </pg-code>
-        </setup>
         <statement>
           <p>
             The graph below shows a power function of the form <m>f(x) = x^{1/n}</m>,

--- a/src/activity-rational-functions.xml
+++ b/src/activity-rational-functions.xml
@@ -169,7 +169,6 @@
     <exercise>
       <title>Determine if each Function is Rational or Not</title>
       <webwork>
-          <setup>
 
             <pg-code>
               $eq1 = RadioButtons(["Rational","Not Rational"],0);
@@ -177,7 +176,6 @@
               $eq3 = RadioButtons(["Rational","Not Rational"],1);
               $eq4 = RadioButtons(["Rational","Not Rational"],0);
             </pg-code>
-          </setup>
           <statement>
             <p>
               <ol label="a">
@@ -297,13 +295,11 @@
       </introduction>
 
       <webwork>
-          <setup>
 
             <pg-code>
               $copper0 = Real(0);
               $copper50 = Real(50);
             </pg-code>
-          </setup>
           <statement>
             <p>
               The percent copper in the alloy stems from the concentration
@@ -374,7 +370,6 @@
       </introduction>
 
       <webwork>
-          <setup>
 
             <pg-code>
   <!-- Put this at the top of the problem setup -->
@@ -454,7 +449,6 @@
   <!-- Then when writing PTX, the answer blanks should be like: -->
   <!-- <var name="$f" evaluator="$evaluator1" width="30" /> -->
             </pg-code>
-          </setup>
           <statement>
             <p>
               <ol>

--- a/src/activity-reflections.xml
+++ b/src/activity-reflections.xml
@@ -783,8 +783,6 @@
               write <em>DNE</em> ("does not exist") in that space.
             </p>
 
-            <sidebyside>
-
               <tabular top="major" halign="center">
                 <col halign="left" />
                 <col />
@@ -840,7 +838,6 @@
                 </row>
               </tabular>
 
-            </sidebyside>
           </statement>
       </webwork>
     </exercise>

--- a/src/activity-reflections.xml
+++ b/src/activity-reflections.xml
@@ -17,7 +17,6 @@
 
   <exercise>
     <webwork>
-        <setup>
 
             <pg-code>
               Context('Numeric');
@@ -28,7 +27,6 @@
               );
               $withNumbers = Real(42);
             </pg-code>
-        </setup>
         <statement>
           <p>
             <ol label ="a">
@@ -102,7 +100,6 @@
 
   <exercise>
     <webwork>
-        <setup>
 
             <pg-code>
               $x=random(3,30,1);
@@ -110,7 +107,6 @@
               $oppX=-1*$x;
               $oppY=-1*$y;
             </pg-code>
-        </setup>
         <statement>
           <p>
             Suppose <m>x = <var name="$x" /></m> and <m>y = <var name="$y" /></m>.
@@ -157,7 +153,6 @@
 
   <exercise>
     <webwork>
-        <setup>
 
             <pg-code>
               Context('Numeric');
@@ -167,7 +162,6 @@
                 displayLabels => 0
               );
             </pg-code>
-        </setup>
         <statement>
           <p>
             [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/rsSg5fd3/width/368/height/261/border/888888/rc/false/ai/false/sdz/false/smb/false/stb/false/stbh/true/ld/false/sri/false/at/auto" width="368px" height="261px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
@@ -229,7 +223,6 @@
 
   <exercise>
     <webwork>
-        <setup>
 
             <pg-code>
               Context('Numeric');
@@ -243,7 +236,6 @@
               $output3=Formula("f(-x)");
               $output4=Formula("-f(x)");
             </pg-code>
-        </setup>
         <statement>
           <p>
             Use the function <m>f(x)</m> to write an expression to answer each question below.
@@ -368,7 +360,6 @@
 
     <exercise>
       <webwork>
-          <setup>
 
             <pg-code>
               $pointOnH=PopUp(
@@ -378,7 +369,6 @@
               ["?","(-4,5)","(-4,-5)","(4,5)","(4,-5)"],"(-4,-5)"
               );
             </pg-code>
-          </setup>
           <statement>
             <p>
               Suppose <m>h(-4) = 5</m>.
@@ -436,7 +426,6 @@
 
     <exercise>
       <webwork>
-          <setup>
 
             <pg-code>
               $fof1=Real(2);
@@ -445,7 +434,6 @@
               ["?","x-axis","y-axis"],"x-axis"
               );
             </pg-code>
-          </setup>
           <statement>
             <p>
               [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/gGZwgNcU/width/425/height/373/border/888888/sdz/false/" width="425px" height="373px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
@@ -511,7 +499,6 @@
 
     <exercise>
       <webwork>
-          <setup>
 
             <pg-code>
               $didItGraph=PopUp(
@@ -523,7 +510,6 @@
               displayLabels => 0
               );
             </pg-code>
-          </setup>
           <statement>
             <p>
               The graph below shows <m>f(x) = \sqrt{x}</m>.
@@ -574,7 +560,6 @@
 
     <exercise>
       <webwork>
-          <setup>
 
             <pg-code>
               $point=PopUp(
@@ -584,7 +569,6 @@
               ["?","(-5, 9)","(-5, 13)"],"(-5, 9)"
               );
             </pg-code>
-          </setup>
           <statement>
             <p>
               Suppose <m>h(5) = 9</m> and
@@ -643,7 +627,6 @@
 
     <exercise>
       <webwork>
-          <setup>
 
             <pg-code>
               $gofneg2notation=PopUp(
@@ -658,7 +641,6 @@
               ["?","x-axis","y-axis"],"y-axis"
               );
             </pg-code>
-          </setup>
           <statement>
             <p>
               The function <m>y = g(x)</m> is shown below.
@@ -735,7 +717,6 @@
 
     <exercise>
       <webwork>
-          <setup>
 
             <pg-code>
               $didItGraph=PopUp(
@@ -747,7 +728,6 @@
               displayLabels => 0
               );
             </pg-code>
-          </setup>
           <statement>
             <p>
               The graph below shows <m>g(x) = \sqrt{x}</m>.
@@ -786,7 +766,6 @@
 
     <exercise>
       <webwork>
-          <setup>
 
             <pg-code>
               @x=(-9,-4,-1,0,1,4,9);
@@ -794,7 +773,6 @@
               @b=map{($_&lt;0)?Compute("DNE"):-sqrt($_)}@x;
               @c=map{($_&gt;0)?Compute("DNE"):sqrt(-$_)}@x;
             </pg-code>
-          </setup>
           <statement>
             <p>
               Complete the table below, using <m>f(x) = \sqrt{x}</m>.
@@ -875,7 +853,6 @@
 
     <exercise>
       <webwork>
-          <setup>
 
             <pg-code>
               $g=PopUp(
@@ -885,7 +862,6 @@
               ["?","-f(x)","f(-x)"],"f(-x)"
               );
             </pg-code>
-          </setup>
           <statement>
             <p>
               The graph below shows <m>y = f(x)</m>.
@@ -925,14 +901,12 @@
 
     <exercise>
       <webwork>
-          <setup>
 
             <pg-code>
               $a=random(3,12,1);
               $g=Compute("-(x+$a)^4");
               $h=Compute("(-x+$a)^4");
             </pg-code>
-          </setup>
           <statement>
             <p>
               The graph below shows <m>f(x) = (x + <var name="$a" />)^4</m>.
@@ -1004,12 +978,10 @@
 
     <exercise>
       <webwork>
-          <setup>
 
             <pg-code>
 
             </pg-code>
-          </setup>
           <statement>
             <p>
               [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/MvQnu5Vm/width/425/height/373/border/888888/sdz/false/" width="425px" height="373px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
@@ -1038,12 +1010,10 @@
 
     <exercise>
       <webwork>
-          <setup>
 
             <pg-code>
 
             </pg-code>
-          </setup>
           <statement>
             <p>
               [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/e6ZcGJS3/width/425/height/373/border/888888/sdz/false/" width="425px" height="373px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*

--- a/src/activity-reflections.xml
+++ b/src/activity-reflections.xml
@@ -11,6 +11,8 @@
 -->
 <section xml:id="activity-reflections" xmlns:xi="http://www.w3.org/2001/XInclude">
   <title>Reflections</title>
+  <subsection>
+    <title>Introduction</title>
   <p>
     To begin this activity, first an exercise about function notation.
   </p>
@@ -335,6 +337,7 @@
         </solution>
     </webwork>
   </exercise>
+  </subsection>
 
   <subsection>
     <title>The transformation <m>y = -f(x)</m></title>

--- a/src/activity-review-percent-change.xml
+++ b/src/activity-review-percent-change.xml
@@ -13,7 +13,7 @@
   <title>Review Percent Change</title>
   <introduction>
     <list>
-      <caption>Topics of Review</caption>
+      <title>Topics of Review</title>
       <ul>
         <li>
           <p>

--- a/src/activity-review-percent-change.xml
+++ b/src/activity-review-percent-change.xml
@@ -244,14 +244,12 @@
     <exercise>
       <title>Identifying the Growth Factor</title>
       <webwork>
-          <setup>
 
             <pg-code>
                 $growth1 = Real(1.0237);
                 $growth2 = Real(1.00104);
                 $growth3 = Real(1.8206);
             </pg-code>
-          </setup>
           <statement>
             <p>
               <ol label="a">
@@ -380,7 +378,6 @@
       </introduction>
 
       <webwork>
-          <setup>
 
         <pg-code>
             $increase1=Real(3.69);
@@ -388,7 +385,6 @@
             $b1=Real(1.075);
             $b2=Real(1.129);
         </pg-code>
-          </setup>
           <stage>
           <statement>
             <p>
@@ -747,7 +743,6 @@
       </introduction>
 
       <webwork>
-          <setup>
 
           <pg-code>
             $rVal1 = Real(0.37);
@@ -756,7 +751,6 @@
             $helped = Real(243);
             $vitaminInc = Real(900);
           </pg-code>
-          </setup>
           <statement>
             <p>
               <ol label="a">

--- a/src/activity-transformations.xml
+++ b/src/activity-transformations.xml
@@ -974,6 +974,7 @@
 
         <p>
           The completed table looks like:
+        </p>
 
           <sidebyside>
 
@@ -1019,8 +1020,6 @@
             </tabular>
 
           </sidebyside>
-
-        </p>
 
         <p>
           [The function <m>f</m> is linear,
@@ -1198,32 +1197,27 @@
         You are already familiar with many basic functions:
       </p>
 
-      <p>
+      <sidebyside>
+        <tabular>
+          <col />
+          <row>
+            <cell><m>y = x</m></cell>
+          </row>
+          <row>
+            <cell><m>y = x^2</m></cell>
+          </row>
+          <row>
+            <cell><m>y = e^x</m></cell>
+          </row>
+          <row>
+            <cell><m>y = log_{10}(x)</m></cell>
+          </row>
+          <row>
+            <cell><m>y = \frac{1}{x}</m></cell>
+          </row>
+        </tabular>
+      </sidebyside>
 
-        <sidebyside>
-
-          <tabular>
-            <col />
-            <row>
-              <cell><m>y = x</m></cell>
-            </row>
-            <row>
-              <cell><m>y = x^2</m></cell>
-            </row>
-            <row>
-              <cell><m>y = e^x</m></cell>
-            </row>
-            <row>
-              <cell><m>y = log_{10}(x)</m></cell>
-            </row>
-            <row>
-              <cell><m>y = \frac{1}{x}</m></cell>
-            </row>
-          </tabular>
-
-        </sidebyside>
-
-      </p>
 
       <p>
         If you know these basic shapes,

--- a/src/activity-transformations.xml
+++ b/src/activity-transformations.xml
@@ -341,9 +341,7 @@
             $grans2=Compute("(x-$shift[2])**2+$shift[3]");
           </pg-code>
           <statement>
-            <sidebyside>
-              <image pg-name="$gr" />
-            </sidebyside>
+            <image pg-name="$gr"/>
 
             <p>
               The graph above shows <m>f(x) = x^2</m>.
@@ -355,18 +353,14 @@
               and write the formula for each graph.
             </p>
 
-            <sidebyside>
-              <image pg-name="$gr1" />
-            </sidebyside>
+            <image pg-name="$gr1"/>
 
             <p>
               The formula is:
               <m>y = </m><var name="$grans1" width="15" />
             </p>
 
-            <sidebyside>
-              <image pg-name="$gr2" />
-            </sidebyside>
+            <image pg-name="$gr2"/>
 
             <p>
               The formula is:
@@ -432,29 +426,19 @@
               The function <m>y = f(x)</m> is shown below.
             </p>
 
-            <sidebyside widths="50%">
-              <image pg-name="$gr[0]"/>
-            </sidebyside>
+            <image pg-name="$gr[0]" width="50%"/>
 
             <p>
               Which of the following graphs shows <m>y = f(x + <var name="$shift[0]" />) + <var name="$shift[1]" /></m>?
             </p>
 
-            <sidebyside widths="60%">
-              <image pg-name="$gr[1]"/>
-            </sidebyside>
+            <image pg-name="$gr[1]" width="60%"/>
 
-            <sidebyside widths="60%">
-              <image pg-name="$gr[2]"/>
-            </sidebyside>
+            <image pg-name="$gr[2]" width="60%"/>
 
-            <sidebyside widths="60%">
-              <image pg-name="$gr[3]"/>
-            </sidebyside>
+            <image pg-name="$gr[3]" width="60%"/>
 
-            <sidebyside widths="60%">
-              <image pg-name="$gr[4]"/>
-            </sidebyside>
+            <image pg-name="$gr[4]" width="60%"/>
 
             <p>
               Answer:
@@ -1252,9 +1236,7 @@
             $formula=Compute("1/(0.625*x)");
           </pg-code>
             <statement>
-              <sidebyside>
-                <image pg-name="$gr" />
-              </sidebyside>
+              <image pg-name="$gr"/>
 
               <p>
                 Above is the function <m>f(x) = \frac{1}{x}</m>.
@@ -1264,9 +1246,7 @@
                 Below, the graph shows a horizontal compression of <m>f</m>.
               </p>
 
-              <sidebyside>
-                <image pg-name="$gr1" />
-              </sidebyside>
+              <image pg-name="$gr1"/>
 
               <p>
                 Use what you know about compressions in order to write the formula for <m>g(x)</m>.

--- a/src/activity-transformations.xml
+++ b/src/activity-transformations.xml
@@ -903,7 +903,7 @@
       for a function and one of its transformations.
     </p>
 
-    <todo>This problem does not recognize when answers have been submitted.</todo>
+    <!-- TODO: This problem does not recognize when answers have been submitted. -->
 
     <exercise>
       <statement>

--- a/src/activity-transformations.xml
+++ b/src/activity-transformations.xml
@@ -43,7 +43,6 @@
 
     <exercise>
       <webwork>
-          <setup>
 
           <pg-code>
             $up=PopUp(
@@ -53,7 +52,6 @@
             ["?","It went up by 3 units.","It went down by 3 units."],"It went down by 3 units."
             );
           </pg-code>
-          </setup>
           <statement>
             <p>
               Let <m>f(x) = x^2</m>.
@@ -123,7 +121,6 @@
 
     <exercise>
       <webwork>
-          <setup>
 
           <pg-code>
             $left4=PopUp(
@@ -133,7 +130,6 @@
             ["?","right 5, and down 4","right 5, and up 4","left 5, and down 4","left 5, and up 4"],"right 5, and down 4"
             );
           </pg-code>
-          </setup>
           <statement>
             <p>
               Again, let <m>f(x) = x^2</m>.
@@ -202,7 +198,6 @@
 
     <exercise>
       <webwork>
-          <setup>
 
           <pg-code>
             $stretched=PopUp(
@@ -215,7 +210,6 @@
             ["?","x-axis","y-axis","line y = x"],"x-axis"
             );
           </pg-code>
-          </setup>
           <statement>
             <p>
               The graph below shows a function <m>y = af(x)</m>,
@@ -322,7 +316,6 @@
 
     <exercise>
       <webwork>
-          <setup>
 
           <pg-code>
             $gr=init_graph(-3,-3,3,3,
@@ -347,7 +340,6 @@
             $grans1=Compute("(x-$shift[0])**2+$shift[1]");
             $grans2=Compute("(x-$shift[2])**2+$shift[3]");
           </pg-code>
-          </setup>
           <statement>
             <sidebyside>
               <image pg-name="$gr" />
@@ -420,7 +412,6 @@
 
     <exercise>
       <webwork>
-          <setup>
 
           <pg-code>
             @shift=map{$_+1}NchooseK(2,2);
@@ -436,7 +427,6 @@
             ["?","Graph 1","Graph 2","Graph 3","Graph 4"],"Graph 3"
             );
           </pg-code>
-          </setup>
           <statement>
             <p>
               The function <m>y = f(x)</m> is shown below.
@@ -503,14 +493,12 @@
 
     <exercise>
       <webwork>
-          <setup>
 
           <pg-code>
             $formulas=PopUp(
             ["?","y=4(x+7)+15","y=4(x+7)-15","y=4(x-7)+15","y=4(x-7)-15"],"y=4(x-7)+15"
             );
           </pg-code>
-          </setup>
           <statement>
             <p>
               The linear function
@@ -575,13 +563,11 @@
 
     <exercise>
       <webwork>
-          <setup>
 
           <pg-code>
             @a=map{1+$_}NchooseK(8,2);
             $whichLine=Compute("11*(x-$a[0])-$a[1]");
           </pg-code>
-          </setup>
           <statement>
             <p>
               The line with slope <m>11</m>,
@@ -618,7 +604,6 @@
 
     <exercise>
       <webwork>
-          <setup>
 
           <pg-code>
             $equation=PopUp(
@@ -626,7 +611,6 @@
             "y = m(x - a) + b"
             );
           </pg-code>
-          </setup>
           <statement>
             <p>
               The equation of a line with slope <m>m</m>,
@@ -713,7 +697,6 @@
 
     <exercise>
       <webwork>
-          <setup>
 
           <pg-code>
             $answer=PopUp(
@@ -725,7 +708,6 @@
             parserFunction("f(x)"=>"(sin(x)+2)/pi");
             $f2=Formula("f(2x)");
           </pg-code>
-          </setup>
           <statement>
             <p>
               The graph below shows a function <m>y = f(x)</m>,
@@ -817,7 +799,6 @@
 
     <exercise>
       <webwork>
-          <setup>
 
           <pg-code>
             $compressed=PopUp(
@@ -833,7 +814,6 @@
             ["y = f(2x)","y = f(0.5x)"],1
             );
           </pg-code>
-          </setup>
           <statement>
             <p>
               [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/pwsX4d5W/width/425/height/373/border/888888/sri/true/sdz/false/" width="425px" height="373px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
@@ -1257,7 +1237,6 @@
 
       <exercise>
         <webwork>
-            <setup>
 
           <pg-code>
             $gr=init_graph(-1,-1,10,2,
@@ -1278,7 +1257,6 @@
             $gr1->stamps( closed_circle(5,0.125,'blue'));
             $formula=Compute("1/(0.625*x)");
           </pg-code>
-            </setup>
             <statement>
               <sidebyside>
                 <image pg-name="$gr" />
@@ -1329,14 +1307,12 @@
 
       <exercise>
         <webwork>
-            <setup>
 
           <pg-code>
             $formula=RadioButtons(
             ["\(2\log_2(x-4)\)","\(\frac{1}{2}\log_2(x-4)\)","\(\log_2(2x-4)\)","\(\log_2\left(\frac{x}{2}-4\right)\)"],2
             );
           </pg-code>
-            </setup>
             <statement>
               <p>
                 [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/hkbdwXA3/width/425/height/373/border/888888/sri/true/sdz/false/" width="425px" height="373px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
@@ -1389,7 +1365,6 @@
 
             <webwork>
 
-                <setup>
                     <pg-code>
                         $answer = random(1,3,1);
                         $gr = init_graph(-1,-1,4,4,
@@ -1410,7 +1385,6 @@
                         $solgr->lineTo($answer,1,'black',3);
                         $solgr->arrowTo($answer,0,'black',3);
                     </pg-code>
-                </setup>
                 <statement>
                     <p>The graph below is a graph of <m>y=f(x)</m>. Use the graph to solve the equation <m>f(x)=1</m>.</p>
                     <figure>

--- a/src/activity-vertical-and-horizontal-translations.xml
+++ b/src/activity-vertical-and-horizontal-translations.xml
@@ -57,14 +57,12 @@
 
     <exercise>
       <webwork>
-          <setup>
 
             <pg-code>
                 $ans1=Compute("(x+6)^2+x+6");
                 $ans2=Compute("x^2+x+6");
                 $ans3=Compute("3*(x^2+x)");
             </pg-code>
-          </setup>
           <statement>
             <p>
               Given the function <m>f(x) = x^2 + x</m>,
@@ -121,7 +119,6 @@
 
     <exercise>
       <webwork>
-          <setup>
 
             <pg-code>
                 Context()->variables->are(t=>'Real');
@@ -129,7 +126,6 @@
                 $ans2=Compute("5(-3(t-4)+7)");
                 $ans3=Compute("-5(-3(t-4)+7)");
             </pg-code>
-          </setup>
           <statement>
             <p>
               Given the function <m>g(t) = -3t + 7</m>,
@@ -202,7 +198,6 @@
 
     <exercise>
       <webwork>
-          <setup>
 
             <pg-code>
                 $ans1=PopUp(["?","adding 4 to the input","adding 4 to the output"],1);
@@ -210,7 +205,6 @@
                 $ans3=PopUp(["?","multiplying the input by 5","multiplying the output by 5"],2);
                 $ans4=PopUp(["?","multiplying the input by 9","multiplying the output by 9"],1);
             </pg-code>
-          </setup>
           <statement>
             <p>
               For each equation below, give a description of what we are changing
@@ -299,7 +293,6 @@
 
     <exercise>
       <webwork>
-          <setup>
 
             <pg-code>
                 Context('Numeric');
@@ -311,7 +304,6 @@
                 $ans2=Formula("g(2*t)-1");
                 $ans3=Formula("7*g(t)");
             </pg-code>
-          </setup>
           <statement>
             <p>
               Beginning with the function <m>y = g(t)</m>,
@@ -483,7 +475,6 @@
 
     <exercise>
       <webwork>
-          <setup>
 
             <pg-code>
                 $start=Real(10);
@@ -494,7 +485,6 @@
                 ["?","It increased slightly","It decreased slightly"],1
                 );
             </pg-code>
-          </setup>
           <statement>
             <p>
               The graph below shows the swimmer's height above the water when she jumped off the regular diving board.
@@ -579,13 +569,11 @@
 
     <exercise>
       <webwork>
-          <setup>
 
             <pg-code>
                 $change=PopUp(["?","added 7 to the input","added 7 to the output","subtracted 7 from the input","subtracted 7 from the output"],2);
                 $eqn=PopUp(["?","h = f(t + 7)","h = f(t) + 7","h = f(t - 7)","h = f(t) - 7"],2);
             </pg-code>
-          </setup>
           <statement>
             <p>
               <ol label="a">
@@ -659,14 +647,12 @@
 
     <exercise>
       <webwork>
-          <setup>
 
             <pg-code>
                 Context('Numeric');
                 Context()->variables->are(t=>'Real');
                 $eqn=Compute("-16t^2+15t+3+7");
             </pg-code>
-          </setup>
           <statement>
             <p>
               Jumping off the regular diving board,
@@ -719,7 +705,6 @@
 
     <exercise>
       <webwork>
-          <setup>
 
             <pg-code>
                 $describeup=PopUp(["?","go up by 25 feet","go down by 25 feet","stay the same"],1);
@@ -729,7 +714,6 @@
                 $eqn1=Compute("-16t^2+15t+3+25");
                 $eqn2=Compute("-16t^2+15t+3-2");
             </pg-code>
-          </setup>
           <statement>
             <p>
               Recall that the swimmer's height above the water,
@@ -828,7 +812,6 @@
 
     <exercise>
       <webwork>
-          <setup>
 
             <pg-code>
                 Context('Numeric');
@@ -839,7 +822,6 @@
                 $eqn1=Formula("f(x)+k");
                 $eqn2=Formula("f(x)-k");
             </pg-code>
-          </setup>
           <statement>
             <p>
               Complete each statement below.
@@ -887,7 +869,6 @@
 
     <exercise>
       <webwork>
-          <setup>
 
             <pg-code>
                 $input=PopUp(
@@ -897,7 +878,6 @@
                 ["?","h = f(t + 2)","h = f(t - 2)"],"h = f(t - 2)"
                 );
             </pg-code>
-          </setup>
           <statement>
             <p>
               The graph below shows
@@ -1015,14 +995,12 @@
 
     <exercise>
       <webwork>
-          <setup>
 
             <pg-code>
                 Context('Numeric');
                 Context()->variables->are(t=>'Real');
                 $eqn=Compute("-16(t-3)^2+15(t-3)+3+7");
             </pg-code>
-          </setup>
           <statement>
             <p>
               Recall that the swimmer's height above the water,
@@ -1060,13 +1038,11 @@
 
     <exercise>
       <webwork>
-          <setup>
 
             <pg-code>
                 $early=PopUp(["?","late","early"],2);
                 $board=PopUp(["?","high-dive","Mega high-dive","Nano"],3);
             </pg-code>
-          </setup>
           <statement>
             <p>
               Recall that the swimmer's height above the water,
@@ -1161,7 +1137,6 @@
 
     <exercise>
       <webwork>
-          <setup>
 
             <pg-code>
                 Context('Numeric');
@@ -1176,7 +1151,6 @@
                     displayLabels => 0
                 );
             </pg-code>
-          </setup>
           <statement>
             <p>
               [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/pXUT7wZS/width/431/height/313/border/888888/smb/false/stb/false/stbh/false/ai/false/asb/false/sri/true/rc/false/ld/false/sdz/false/ctl/false" width="431px" height="313px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
@@ -1230,7 +1204,6 @@
 
     <exercise>
       <webwork>
-          <setup>
 
             <pg-code>
                 Context('Numeric');
@@ -1245,7 +1218,6 @@
                     displayLabels => 0
                 );
             </pg-code>
-          </setup>
           <statement>
             <p>
               [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/qHkxbUVg/width/431/height/313/border/888888/rc/false/ai/false/sdz/false/smb/false/stb/false/stbh/true/ld/false/sri/false/at/auto" width="431px" height="313px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
@@ -1291,12 +1263,10 @@
 
     <exercise>
       <webwork>
-          <setup>
 
             <pg-code>
                 $formulas=PopUp(["?","y=4(x+7)+15","y=4(x+7)-15","y=4(x-7)+15","y=4(x-7)-15"],3);
             </pg-code>
-          </setup>
           <statement>
             <p>
               The linear function
@@ -1357,13 +1327,11 @@
 
     <exercise>
       <webwork>
-          <setup>
 
             <pg-code>
                 @a=map{1+$_}NchooseK(8,2);
                 $whichLine=Compute("11*(x-$a[0])-$a[1]");
             </pg-code>
-          </setup>
           <statement>
             <p>
               The line with slope <m>11</m>,
@@ -1399,12 +1367,10 @@
 
     <exercise>
       <webwork>
-          <setup>
 
             <pg-code>
                 $equation=PopUp(["?","y = m(x - a) + b","y = mx - a + b","y = m(x - b) + a"],1);
             </pg-code>
-          </setup>
           <statement>
             <p>
               The equation of a line with slope <m>m</m>,

--- a/src/activity-vertical-stretches.xml
+++ b/src/activity-vertical-stretches.xml
@@ -239,8 +239,6 @@
               of a function by a number will change its <em>output</em> values.
             </p>
 
-            <sidebyside>
-
               <tabular top="major" halign="center">
                 <col halign="left" />
                 <col />
@@ -284,7 +282,6 @@
                 </row>
               </tabular>
 
-            </sidebyside>
           </statement>
       </webwork>
     </exercise>

--- a/src/activity-vertical-stretches.xml
+++ b/src/activity-vertical-stretches.xml
@@ -34,7 +34,6 @@
 
   <exercise>
     <webwork>
-        <setup>
 
         <pg-code>
           Context('Numeric');
@@ -46,7 +45,6 @@
           $output=Formula("$num[0]*g($num[1])");
           $output1=Formula("$num[2]*f(x)");
         </pg-code>
-        </setup>
         <statement>
           <p>
             If <m>g</m> is a function,
@@ -99,7 +97,6 @@
 
   <exercise>
     <webwork>
-        <setup>
 
         <pg-code>
           $interpret1=PopUp(
@@ -109,7 +106,6 @@
           ["?","the output divided by 3","the output multiplied by 1/3","all of the above"],"all of the above"
           );
         </pg-code>
-        </setup>
         <statement>
           <p>
             <ol label="a">
@@ -167,14 +163,12 @@
 
   <exercise>
     <webwork>
-        <setup>
 
         <pg-code>
           $exp=PopUp(
           ["?","f(0.5x)","0.5f(x)"],"0.5f(x)"
           );
         </pg-code>
-        </setup>
         <statement>
           <p>
             Suppose the function <m>f(x)</m> represents the price of your favorite whole bean coffee,
@@ -214,7 +208,6 @@
 
     <exercise>
       <webwork>
-          <setup>
 
         <pg-code>
           @x=(0,1,4,7,11);
@@ -223,7 +216,6 @@
           @b=map{2*$_}@a;
           @c=map{0.5*$_}@a;
         </pg-code>
-          </setup>
           <statement>
             <p>
               [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/dAA6utJV/width/433/height/376/border/888888/sri/true/sdz/false/" width="433px" height="376px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
@@ -300,14 +292,12 @@
 
     <exercise>
       <webwork>
-          <setup>
 
         <pg-code>
           $didItGraph=PopUp(
           ["?","no","yes"],"yes"
           );
         </pg-code>
-          </setup>
           <stage>
           <statement>
             <p>
@@ -386,7 +376,6 @@
 
     <exercise>
       <webwork>
-          <setup>
 
         <pg-code>
           $verticalStretch = PopUp(
@@ -396,7 +385,6 @@
           ["?","stretch it away from","compress it toward"],"compress it toward"
           );
         </pg-code>
-          </setup>
           <statement>
             <p>
               The graph below shows a function <m>y = f(x)</m>.
@@ -448,13 +436,11 @@
 
     <exercise>
       <webwork>
-          <setup>
 
         <pg-code>
           $reflection=PopUp(["?","reflected over the x-axis","reflected over the y-axis"],"reflected over the x-axis");
           $stretch=PopUp(["?","vertically compressed by a factor of 1/2","vertically stretched by a factor of 2"],"vertically stretched by a factor of 2");
         </pg-code>
-          </setup>
           <statement>
             <p>
               The graph below shows a function <m>y = f(x)</m>.
@@ -488,14 +474,12 @@
 
     <exercise>
       <webwork>
-          <setup>
 
       <pg-code>
         $val=random(1.5,2.5,3.5,4.5);
         $height=$val*8;
         $formula=Compute("$val*x^3");
       </pg-code>
-          </setup>
           <statement>
             <p>
               The function <m>y = f(x) = x^3</m> contains the points <m>(0, 0)</m> and <m>(2, 8)</m>.
@@ -556,12 +540,10 @@
 
     <exercise>
       <webwork>
-          <setup>
 
         <pg-code>
           $description=RadioButtons(["The transformations \(a*f(x)\) and \(f(x) + a\) are really the same thing.","The transformation \(a*f(x)\) stretches or compresses the graph vertically, but \(f(x) + a\) shifts the graph up or down.","The transformation \(a*f(x)\) shifts the graph up or down, but \(f(x) + a\) stretches or compresses the graph vertically.","The transformation \(a*f(x)\) changes the graph vertically, but \(f(x) + a\) changes the graph horizontally."],1,labels => ["Same","af(x) stretches, f(x)+a shifts","af(x) shifts, f(x)+a stretches","af(x) vertical change, f(x)+a horizontal change"],displayLabels => 0);
         </pg-code>
-          </setup>
           <statement>
             <p>
               Which statement below correctly describes the difference between the transformations <m>a\cdot f(x)</m> and <m>f(x) + a</m>?

--- a/src/activity-vertical-stretches.xml
+++ b/src/activity-vertical-stretches.xml
@@ -11,6 +11,8 @@
 -->
 <section xml:id="activity-vertical-stretches" xmlns:xi="http://www.w3.org/2001/XInclude">
   <title>Vertical Stretches</title>
+  <subsection>
+    <title>Introduction</title>
   <p>
     In this activity,
     we will continue to explore how a change to a function's formula will alter its graph.
@@ -195,6 +197,7 @@
         </solution>
     </webwork>
   </exercise>
+  </subsection>
   <!-- TODO: Change problem to allow for answers in a range-->
   <subsection>
     <title>Effects on the graph</title>

--- a/src/chapter-combinations-of-functions.xml
+++ b/src/chapter-combinations-of-functions.xml
@@ -26,6 +26,8 @@
 
   <section xml:id="combination-of-functions-gist">
     <title>Gist of Combinations of Functions</title>
+    <subsection>
+      <title>Introduction</title>
     <p>
       A <term>combination of functions</term><idx><h>function</h><h>combination</h></idx> is the result of performing arithmetic operations on the outputs of two or more functions.
     </p>
@@ -516,6 +518,7 @@
         </p>
       </solution>
     </example>
+    </subsection>
 
     <subsection>
       <title>Graphing Combinations</title>

--- a/src/chapter-combinations-of-functions.xml
+++ b/src/chapter-combinations-of-functions.xml
@@ -907,8 +907,6 @@
               answer the questions that follow.
             </p>
 
-            <sidebyside>
-
               <tabular top="major" halign="center">
                 <col halign="left" />
                 <col />
@@ -939,8 +937,6 @@
                   <cell><m>24</m></cell>
                 </row>
               </tabular>
-
-            </sidebyside>
 
             <p>
               <ol label="$a">
@@ -1102,8 +1098,6 @@
                   The table below shows values of two functions, <m>f</m> and <m>g</m>.
                 </p>
 
-                <sidebyside>
-
                   <tabular top="major" halign="center">
                     <col halign="left" />
                     <col />
@@ -1137,8 +1131,6 @@
                     </row>
                   </tabular>
 
-                </sidebyside>
-
                 <p>
                   The three other functions are defined as follows:
                 </p>
@@ -1171,8 +1163,6 @@
                 </p>
               </statement>
               <solution>
-                <sidebyside>
-
                   <tabular top="major" halign="center">
                     <col halign="left" />
                     <col />
@@ -1229,8 +1219,6 @@
                       <cell><var name="$P[4]" /></cell>
                     </row>
                   </tabular>
-
-                </sidebyside>
               </solution>
           </webwork>
         </exercise>

--- a/src/chapter-combinations-of-functions.xml
+++ b/src/chapter-combinations-of-functions.xml
@@ -109,7 +109,6 @@
 
     <exercise>
       <webwork>
-          <setup>
 
             <pg-code>
               @a=map{$_+1}NchooseK(4,2);
@@ -120,7 +119,6 @@
               $f10=$a[0]*10+$a[1];
               $f102=2*($a[0]*10+$a[1]);
             </pg-code>
-          </setup>
           <statement>
             <p>
               Let <m>f(x) = <var name="$a[0]" />x + <var name="$a[1]" /></m> and <m>g(x) = <var name="$b[0]" />x + <var name="$b[1]" /></m>.
@@ -247,7 +245,6 @@
 
     <exercise>
       <webwork>
-          <setup>
 
             <pg-code>
               $profitIsZero=Real(5);
@@ -260,7 +257,6 @@
               $p1=$r1-$c1;
               $p2=$r2-$c2;
             </pg-code>
-          </setup>
           <statement>
             <p>
               In business, we use the equation
@@ -555,11 +551,9 @@
 
       <exercise>
         <webwork>
-            <setup>
 
             <pg-code>
             </pg-code>
-            </setup>
             <statement>
               <p>
                 The graphs of <m>f(x) = x - 1</m> and <m>g(x) = 2 - x</m> are shown below.
@@ -666,11 +660,9 @@
 <!--
         <exercise>
           <webwork>
-            <setup>
               <pg-code>
                 $itemCost=Compute("24-0.25*(x-1)");
               </pg-code>
-            </setup>
 
             <statement>
               <p>Write a formula for the unit cost, <m>C(x)</m>, of each item when the customer orders <m>x</m> of the items.</p>
@@ -687,13 +679,11 @@
 
         <exercise>
           <webwork>
-            <setup>
               <pg-code>
                 $x=random(10,20,1);
                 $itemCost=24-0.25*($x-1);
                 $totalCost=$x*$itemCost;
               </pg-code>
-            </setup>
             <statement>
               <p>If a customer ordered <var name="$x" /> items, what would be the unit cost?</p>
               <p><m>C(</m><var name="$x" /><m>) = </m><var name="$itemCost" width="15"/> $/item</p>
@@ -714,14 +704,12 @@
 
         <exercise>
           <webwork>
-            <setup>
 
               <pg-code>
                 $sold=Compute("x");
                 $unitCost=Compute("24-0.25*(x-1)");
                 $totalCost=Compute("(24-0.25*(x-1))*x");
               </pg-code>
-            </setup>
 
             <statement>
               <p>The total cost function, <m>T(x)</m>, may be thought of as a combination of two different functions, <m>C(x)</m> and <m>Q(x)</m>.</p>
@@ -853,13 +841,11 @@
 
       <exercise>
         <webwork>
-          <setup>
 
             <pg-code>
               $yValues=PopUp(["?","x values","y values"],"y values");
               $false=PopUp(["?","true","false"],"false");
             </pg-code>
-          </setup>
           <statement>
             <p>
               Consider functions <m>y = f(x)</m> and <m>y = g(x)</m>.
@@ -902,13 +888,11 @@
 
       <exercise>
         <webwork>
-          <setup>
 
             <pg-code>
               $ans1=PopUp(["?","c(3)","c(5)","c(6)","c(7)"],"c(5)");
               $ans2=Real(1);
             </pg-code>
-          </setup>
           <statement>
             <p>
               Consider the functions <m>a(x)</m>, <m>b(x)</m>, <m>c(x)=a(x)+b(x)</m>
@@ -999,7 +983,6 @@
 
       <exercise>
         <webwork>
-          <setup>
 
             <pg-code>
               $ans1=PopUp(["?","12R(x)+12D(x)","R(12)D(12)","R(12)+D(12)","R(D(12))"],"R(12)+D(12)");
@@ -1014,7 +997,6 @@
               Context()->flags->set(formatStudentAnswer=>"parsed");
               $ans3=Formula("R(12)r(12)+D(12)d(12)");
             </pg-code>
-          </setup>
           <statement>
             <p>
               Consider the functions below:
@@ -1105,7 +1087,6 @@
 
         <exercise>
           <webwork>
-              <setup>
 
             <pg-code>
               @x=(2,4);
@@ -1115,7 +1096,6 @@
               @N=map{$f[$_]-$g[$_]}0..$#f;
               @P=map{$f[$_]*$g[$_]}0..$#f;
             </pg-code>
-              </setup>
               <statement>
                 <p>
                   The table below shows values of two functions, <m>f</m> and <m>g</m>.

--- a/src/chapter-combinations-of-functions.xml
+++ b/src/chapter-combinations-of-functions.xml
@@ -412,7 +412,7 @@
       </webwork>
     </exercise>
 
-    <todo>Make a better item to sell in the next problem.</todo>
+    <!-- TODO: Make a better item to sell in the next problem. -->
 
     <example>
       <statement>

--- a/src/chapter-combinations-of-functions.xml
+++ b/src/chapter-combinations-of-functions.xml
@@ -1061,8 +1061,6 @@
               </ul>
             </p>
           </statement>
-          <solution>
-          </solution>
         </webwork>
       </exercise>
 

--- a/src/chapter-composition-and-inverse.xml
+++ b/src/chapter-composition-and-inverse.xml
@@ -1665,7 +1665,7 @@
         so that the output never has repeated values <mdash /> this ensures that the inverse will pass the vertical line test.
       </p>
 
-      <todo>Add content about one to one, onto, and the domain and range relationship between a function and its inverse.</todo>
+      <!-- TODO: Add content about one to one, onto, and the domain and range relationship between a function and its inverse. -->
     </subsection>
 
     <subsection>

--- a/src/chapter-composition-and-inverse.xml
+++ b/src/chapter-composition-and-inverse.xml
@@ -2509,8 +2509,6 @@
                   Remember to evaluate first inside the parentheses.
                 </p>
 
-                <sidebyside>
-
                   <tabular top="major" halign="center">
                     <col halign="left" />
                     <col />
@@ -2560,7 +2558,6 @@
                     </row>
                   </tabular>
 
-                </sidebyside>
               </statement>
               <hint>
                 <p>
@@ -2570,8 +2567,6 @@
                 </p>
               </hint>
               <solution>
-                <sidebyside>
-
                   <tabular top="major" halign="center">
                     <col halign="left" />
                     <col />
@@ -2620,8 +2615,6 @@
                       <cell><m><var name="$QofP[5]" /></m></cell>
                     </row>
                   </tabular>
-
-                </sidebyside>
               </solution>
           </webwork>
         </exercise>
@@ -3220,8 +3213,6 @@
                   and the wind is blowing at <m>S</m> miles per hour.
                 </p>
 
-                <sidebyside>
-
                   <tabular top="major" halign="center">
                     <col halign="left" />
                     <col />
@@ -3258,8 +3249,6 @@
                       <cell><m><var name="$f[6]" /></m></cell>
                     </row>
                   </tabular>
-
-                </sidebyside>
 
                 <p>
                   Which pair of statements is true?

--- a/src/chapter-composition-and-inverse.xml
+++ b/src/chapter-composition-and-inverse.xml
@@ -155,12 +155,10 @@
 
       <exercise xml:id="exercise-composition-formulas">
         <webwork>
-            <setup>
 
             <pg-code>
               Context("LimitedRadical");
             </pg-code>
-            </setup>
             <statement>
               <p>
                 Let <m>f(x) = 3x + 4</m> and <m>g(x) = x^2 + x</m>.
@@ -378,7 +376,6 @@
 
       <exercise>
         <webwork>
-            <setup>
 
             <pg-code>
               Context('Numeric');
@@ -386,7 +383,6 @@
               $conAtHours=Compute("5*2.718282**(-0.058*$hours)");
               $bpAtHours=Compute("-12.5*$conAtHours+172.5");
             </pg-code>
-            </setup>
             <statement>
               <p>
                 The blood pressure drug <em>lisinopril</em>
@@ -490,7 +486,6 @@
 
       <exercise>
         <webwork>
-            <setup>
 
             <pg-code>
               Context()->variables->are(t=>'Real', C=>'Real');
@@ -498,7 +493,6 @@
                 ["\(-12.5\left(5e^{-0.058t}\right)+172.5\)",
                  "\(5e^{-0.058(-12.5C+172.5)}\)"],0);
             </pg-code>
-            </setup>
             <statement>
               <p>
                 If we wanted to,
@@ -799,7 +793,6 @@
 
       <exercise>
         <webwork>
-            <setup>
 
             <pg-code>
               $m=random(25,35,1);
@@ -810,7 +803,6 @@
               $year=2000+$x[0];
               $interpret=PopUp(["?","When the population was $y[0], it was the year $year","In the year $y[0], the population was $x[0]"],"When the population was $y[0], it was the year $year");
             </pg-code>
-            </setup>
             <statement>
               <p>
                 Let <m>P(t)</m> be the function which calculates the population of a small town,
@@ -1027,13 +1019,11 @@
 
       <exercise>
         <webwork>
-            <setup>
 
             <pg-code>
               $didItGraph=PopUp(["?","No","Yes"],2);
               $reflection=PopUp(["?","line y = x","x-axis","y-axis"],1);
             </pg-code>
-            </setup>
             <statement>
               <p>
                 [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/ssqjr6pZ/width/425/height/373/border/888888/sdz/false/" width="425px" height="373px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
@@ -1470,12 +1460,10 @@
 
       <exercise>
         <webwork>
-            <setup>
 
             <pg-code>
               $reason=PopUp(["?","A horizontal line would cross the graph of y=f(x) twice.","A vertical line would cross the graph of the inverse twice.","All of the above."],3);
             </pg-code>
-            </setup>
             <statement>
               <p>
                 [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/fTMWxxhS/width/425/height/373/border/888888/sdz/false/" width="425px" height="373px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
@@ -1621,12 +1609,10 @@
 
       <exercise>
         <webwork>
-            <setup>
 
             <pg-code>
               $interval=PopUp(["?","x >= 0","x >= -2"],1);
             </pg-code>
-            </setup>
             <statement>
               <p>
                 [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/jGC9Xk8r/width/425/height/373/border/888888/sdz/false/" width="425px" height="373px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
@@ -1697,7 +1683,6 @@
 
       <exercise>
         <webwork>
-          <setup>
 
             <pg-code>
               Context('Numeric');
@@ -1710,7 +1695,6 @@
               $b=Formula("f(13)");
               $c=Formula("g(f(19))");
             </pg-code>
-          </setup>
           <statement>
             <p>
               Suppose <m>M = f(t)</m> represents the number of members in the voting party,
@@ -1786,7 +1770,6 @@
 
       <exercise>
         <webwork>
-          <setup>
 
             <pg-code>
               $distance=random(4,7,1);
@@ -1804,7 +1787,6 @@
               $composite=Formula("f(g(2.5))");
 
             </pg-code>
-          </setup>
           <statement>
             <p>
               Your favorite peer-to-peer ridehailing service has the following price
@@ -1948,7 +1930,6 @@
 
       <exercise>
         <webwork>
-          <setup>
 
             <pg-code>
               @a=map{$_+3}NchooseK(7,5);
@@ -1957,7 +1938,6 @@
               $y1=Compute("$a[0]*($a[3]*$x1-$a[4])**2-$a[1]*($a[3]*$x1-$a[4])+$a[2]");
               $y2=Compute("$a[3]*($a[0]*($x2)**2-$a[1]*$x2+$a[2])-$a[4]");
             </pg-code>
-          </setup>
           <statement>
             <p>
               In this problem, use the functions
@@ -2017,7 +1997,6 @@
 
       <exercise>
         <webwork>
-          <setup>
 
             <pg-code>
               Context('Numeric');
@@ -2034,7 +2013,6 @@
               $formula4=Formula("j(g(x))");
               $formula5=Formula("f(f(x))");
             </pg-code>
-          </setup>
           <statement>
             <p>
               In this problem, use the functions
@@ -2129,7 +2107,6 @@
 
       <exercise>
         <webwork>
-          <setup>
 
             <pg-code>
               $a=2*random(1,5,1);
@@ -2139,7 +2116,6 @@
               do{$y2=random(2,15,1);}until($y2!=$y1);
               $x2=Compute("($y2+$b)/$a");
             </pg-code>
-          </setup>
           <statement>
             <p>
               Use the function <m>f(x) = <var name="$a" />x - <var name="$b" /></m>
@@ -2200,7 +2176,6 @@
 
       <exercise>
         <webwork>
-          <setup>
 
             <pg-code>
               $formula1 = RadioButtons(
@@ -2215,7 +2190,6 @@
                   displayLabels => 0
               );
             </pg-code>
-          </setup>
           <statement>
             <p>
               For each equation involving a logarithm, choose the corresponding exponential
@@ -2275,7 +2249,6 @@
 
       <exercise>
         <webwork>
-          <setup>
 
             <pg-code>
               $formula1 = RadioButtons(
@@ -2290,7 +2263,6 @@
                   displayLabels => 0
               );
             </pg-code>
-          </setup>
           <statement>
             <p>
               For each equation involving an exponent, choose the corresponding logarithm
@@ -2350,13 +2322,11 @@
 
       <exercise>
         <webwork>
-          <setup>
 
             <pg-code>
               $true=PopUp(["?","true","false"],"true");
               $false=PopUp(["?","true","false"],"false");
             </pg-code>
-          </setup>
           <statement>
             <p>
               Remembering that exponential functions and logarithms (with the same base)
@@ -2465,7 +2435,6 @@
 
       <exercise>
         <webwork>
-            <setup>
 
           <pg-code>
             $num=random(2,8,1);
@@ -2474,7 +2443,6 @@
             $fog=Compute("4*$g-3");
             $gof=Compute("$f**2-1");
           </pg-code>
-            </setup>
             <statement>
               <p>
                 Let <m>f(x)=4x-3</m> and <m>g(x)=x^2-1</m>.
@@ -2519,7 +2487,6 @@
 
         <exercise>
           <webwork>
-              <setup>
 
       <pg-code>
         @x=(0,1,2,3,4,5);
@@ -2532,7 +2499,6 @@
         $QofP[4]=$Q[$P[4]];
         $QofP[5]=$Q[$P[5]];
       </pg-code>
-              </setup>
               <statement>
                 <p>
                   The table below has values for functions <m>P(x)</m> and <m>Q(x)</m>.
@@ -2691,7 +2657,6 @@
 
         <exercise>
           <webwork>
-              <setup>
 
       <pg-code>
         $GofF=Compute("(x/(x+4))^2");
@@ -2699,7 +2664,6 @@
         $G=Compute("x^2");
         $FofG=Compute("x^2/(x^2+4)");
       </pg-code>
-              </setup>
               <statement>
                 <p>
                   Let <m>f(x) = \frac{x}{x+4}</m> and <m>g(x) = x^2</m>.
@@ -2988,7 +2952,6 @@
 
         <exercise>
           <webwork>
-              <setup>
 
       <pg-code>
         Context("Inequalities");
@@ -3011,7 +2974,6 @@
           return 0;
         });
       </pg-code>
-              </setup>
               <statement>
                 <p>
                   An important use of restricting the domain is in finding the inverse of a
@@ -3066,13 +3028,11 @@
 
         <exercise>
           <webwork>
-              <setup>
 
       <pg-code>
         $totalCost=PopUp(["?","A(V(w)) + B(T(w))","V(w) + T(w)","T(V(w)) + B(A(m))","V(w)T(w)"],"A(V(w)) + B(T(w))");
         $totalMiles=PopUp(["?","V(T(w)) + T(V(w))","V(A(m))","V(w)T(w)","V(w) + T(w)"],"V(w) + T(w)");
       </pg-code>
-              </setup>
               <statement>
                 <p>
                   Your company has a fleet of vehicles that transport goods around the metropolitan area.
@@ -3167,13 +3127,11 @@
 
         <exercise>
           <webwork>
-              <setup>
 
       <pg-code>
         $revenue=PopUp(["?","f(g(5))","g(f(5))","f(5) + g(5)","f(5)g(5)"],"f(5)g(5)");
         $taxes=PopUp(["?","h(5)","h(f(5)g(5))","h(f(5))","h(g(f(5)))"],"h(f(5)g(5))");
       </pg-code>
-              </setup>
               <statement>
                 <p>
                   On your popular YouTube channel,
@@ -3239,7 +3197,6 @@
 
         <exercise>
           <webwork>
-              <setup>
 
         <pg-code>
           @rand=map{$_+1}NchooseK(6,4);
@@ -3251,7 +3208,6 @@
              "\($w[1]\) and \($i[1]\)");
           $statements=RadioButtons(~~@s,1);
       </pg-code>
-              </setup>
               <statement>
                 <p>
                   On a cold day, when the wind blows,

--- a/src/chapter-composition-and-inverse.xml
+++ b/src/chapter-composition-and-inverse.xml
@@ -3322,8 +3322,6 @@
               a function <m>f</m> will output that employee's ID Number.
               If they enter an employee's ID Number,
               then various functions can be used:
-            </p>
-
             <ul>
               <li>
                 <p>
@@ -3373,6 +3371,7 @@
                 </p>
               </li>
             </ol>
+            </p>
           </statement>
         </exercise>
 

--- a/src/chapter-composition-and-inverse.xml
+++ b/src/chapter-composition-and-inverse.xml
@@ -2982,9 +2982,7 @@
                   For example, consider the function <m>f</m> below.
                 </p>
 
-                <sidebyside>
-                  <image pg-name="$gr" />
-                </sidebyside>
+                <image pg-name="$gr"/>
 
                 <p>
                   How could we restrict the domain so this function is invertible?

--- a/src/chapter-domain-and-range-piecewise.xml
+++ b/src/chapter-domain-and-range-piecewise.xml
@@ -518,7 +518,7 @@
         write each formula with its corresponding domain to its right.
       </p>
 
-      <todo>It would be nice if the student could enter their answers in such a way that in the end the answer looks like proper piecewise notation as shown in the solution.</todo>
+      <!-- TODO: It would be nice if the student could enter their answers in such a way that in the end the answer looks like proper piecewise notation as shown in the solution. -->
 
       <exercise>
         <webwork>

--- a/src/chapter-domain-and-range-piecewise.xml
+++ b/src/chapter-domain-and-range-piecewise.xml
@@ -1847,7 +1847,7 @@
         </exercise>
 
       </exercisegroup>
-      <exercisegroup>
+      <!-- <exercisegroup>
 
         <introduction>
           <p>
@@ -1855,7 +1855,7 @@
           </p>
         </introduction>
 
-      </exercisegroup>
+      </exercisegroup> -->
     </exercises>
   </section>
 </chapter>

--- a/src/chapter-domain-and-range-piecewise.xml
+++ b/src/chapter-domain-and-range-piecewise.xml
@@ -784,8 +784,9 @@
           <statement>
             <p>
               Consider the function <m>y=g(x)</m> below.
-              <image pg-name="$gr" />
             </p>
+
+            <image pg-name="$gr" />
 
             <p>
               <ol label="a">
@@ -856,8 +857,9 @@
           <statement>
             <p>
               Consider the function <m>y=g(x)</m> below.
-              <image pg-name="$gr" />
             </p>
+
+            <image pg-name="$gr" />
 
             <p>
               <ol label="a">
@@ -952,8 +954,9 @@
           <statement>
             <p>
               Consider the function <m>y=g(x)</m> below.
-              <image pg-name="$gr" />
             </p>
+
+            <image pg-name="$gr" />
 
             <p>
               Determine the formulas for this function.
@@ -1036,8 +1039,8 @@
             <p>
               Use the graph of <m>y=h(x)</m> below to answer the questions that follow.
               If a value does not exist, you should type <em>DNE</em>.
-              <image pg-name="$gr" />
             </p>
+            <image pg-name="$gr" />
             <p>
               <ol label="a">
                 <li>
@@ -1430,8 +1433,8 @@
           <statement>
             <p>
               Use the graph of <m>y=h(x)</m> below to answer the questions that follow.
-              <image pg-name="$gr" />
             </p>
+            <image pg-name="$gr" />
             <p>
               <ol label="a">
                 <li>

--- a/src/chapter-domain-and-range-piecewise.xml
+++ b/src/chapter-domain-and-range-piecewise.xml
@@ -329,7 +329,6 @@
 
       <exercise>
         <webwork>
-            <setup>
 
             <pg-code>
               Context("Inequalities");
@@ -338,7 +337,6 @@
               $rng1 = Compute("1.5&lt;=y&lt;3.5");
               $rng2 = Compute("3&lt;=y&lt;5");
             </pg-code>
-            </setup>
             <stage>
             <statement>
               <p>
@@ -524,7 +522,6 @@
 
       <exercise>
         <webwork>
-            <setup>
 
             <pg-code>
                 Context()->variables->are(x=>'Real',y=>'Real');
@@ -534,7 +531,6 @@
                 $answer1 = Compute("-5&lt;=x&lt;0");
                 $answer2 = Compute("1&lt;=x&lt;=4");
             </pg-code>
-            </setup>
             <statement>
               <p>
                 [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/tVFj33nG/width/431/height/313/border/888888/sri/true" width="431px" height="313px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
@@ -579,7 +575,6 @@
       <exercise>
         <title>Match the Graph to the Piecewise Formula</title>
         <webwork>
-            <setup>
 
             <pg-code>
               $one = RadioButtons(
@@ -587,7 +582,6 @@
               2, labels => ["Function A","Function B","Function C"],displayLabels => 0
               );
             </pg-code>
-            </setup>
             <statement>
               <p>
                 [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/UY2xPaVW/width/413/height/300/border/888888" width="413px" height="300px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
@@ -647,7 +641,6 @@
 
       <exercise>
         <webwork>
-          <setup>
 
             <pg-code>
               $a=random(2,13);
@@ -655,7 +648,6 @@
               $gDomain=PopUp(["?","greater than zero","less than zero","greater than or equal to zero",
               "less than or equal to zero"],"greater than or equal to zero");
             </pg-code>
-          </setup>
           <statement>
             <p>
               Use the functions below to answer the questions that follow.
@@ -706,7 +698,6 @@
 
       <exercise>
         <webwork>
-          <setup>
 
             <pg-code>
               $a=random(3,10);
@@ -718,7 +709,6 @@
               $PDomain=Compute("$b/$a");
               $greaterThanOrEqual=PopUp(["?","greater than","less than","greater than or equal to","less than or equal to"],"greater than or equal to");
             </pg-code>
-          </setup>
           <statement>
             <p>
               Use the functions below to answer the questions that follow.
@@ -776,7 +766,6 @@
 
       <exercise>
         <webwork>
-          <setup>
 
             <pg-code>
               $gr=init_graph(-8,-8,8,8,axes=>[0,0],grid=>[16,16],size=>[240,240]);
@@ -792,7 +781,6 @@
               $xVar=PopUp(["?","x","y"],"x");
               $yVar=PopUp(["?","x","y"],"y");
             </pg-code>
-          </setup>
           <statement>
             <p>
               Consider the function <m>y=g(x)</m> below.
@@ -845,7 +833,6 @@
 
       <exercise>
         <webwork>
-          <setup>
 
             <pg-code>
               $gr=init_graph(-10,-10,10,10,axes=>[0,0],grid=>[20,20],size=>[240,240]);
@@ -866,7 +853,6 @@
               $notInDomain=PopUp(["?","0","1","2","3","4","5","infinitely many"],"3");
               $notInRange=PopUp(["?","0","1","2","3","4","5","infinitely many"],"5");
             </pg-code>
-          </setup>
           <statement>
             <p>
               Consider the function <m>y=g(x)</m> below.
@@ -943,7 +929,6 @@
 
       <exercise>
         <webwork>
-          <setup>
 
             <pg-code>
               $gr=init_graph(-10,-10,10,10,axes=>[0,0],grid=>[20,20],size=>[240,240]);
@@ -964,7 +949,6 @@
               $eqn2=Formula("4");
               $eqn3=Formula("x-2");
             </pg-code>
-          </setup>
           <statement>
             <p>
               Consider the function <m>y=g(x)</m> below.
@@ -1022,7 +1006,6 @@
 
       <exercise>
         <webwork>
-          <setup>
 
             <pg-code>
               $gr=init_graph(-10,-10,10,10,axes=>[0,0],grid=>[20,20],size=>[240,240]);
@@ -1049,7 +1032,6 @@
               $point2=Compute("(4,8)");
               $fillCircle=OneOf($point1,$point2);
             </pg-code>
-          </setup>
           <statement>
             <p>
               Use the graph of <m>y=h(x)</m> below to answer the questions that follow.
@@ -1133,13 +1115,11 @@
 
       <exercise>
         <webwork>
-            <setup>
 
             <pg-code>
               $cost=Real(60);
               $units=PopUp(["?","dollars","hours"],"dollars");
             </pg-code>
-            </setup>
             <statement>
               <p>
                 <em>Tools of the Trade</em> rental shop will rent a pressure washer for <m>\$35</m> for the first two hours,
@@ -1179,7 +1159,6 @@
 
       <exercise>
         <webwork>
-            <setup>
 
             <pg-code>
               $input1=random(5,19,1);
@@ -1189,7 +1168,6 @@
               $output2=Compute("250+($input2-20)*11");
               $input2units=PopUp(["?","dollars","shirts"],"shirts");
             </pg-code>
-            </setup>
             <statement>
               <p>
                 A T-shirt printer sells custom-printed shirts for
@@ -1253,14 +1231,12 @@
 
       <exercise>
         <webwork>
-            <setup>
             <pg-code>
               $ans1=Real(3);
               $ans2=Real(2);
               $ans3=PopUp(["?","one","two","three","infinitely many"],"infinitely many");
               $ans4=PopUp(["?","one","two","three","infinitely many"],"two");
             </pg-code>
-            </setup>
             <statement>
               <p>
                 <me>
@@ -1359,12 +1335,10 @@
 
       <exercise>
         <webwork>
-          <setup>
 
             <pg-code>
               $yes=PopUp(["?","yes","no"],"yes");
             </pg-code>
-          </setup>
           <statement>
             <p>
               Consider the function <m>y=f(x)</m> below.
@@ -1393,12 +1367,10 @@
 
       <exercise>
         <webwork>
-          <setup>
 
             <pg-code>
               $C=Real(7);
             </pg-code>
-          </setup>
           <statement>
             <p>
               Consider the function <m>y=g(x)</m> below.
@@ -1436,7 +1408,6 @@
 
       <exercise>
         <webwork>
-          <setup>
 
             <pg-code>
               $gr=init_graph(-10,-10,10,10,axes=>[0,0],grid=>[20,20],size=>[240,240]);
@@ -1456,7 +1427,6 @@
               $notContinuous=PopUp(["?","Yes, it would be continuous","No, it would not be continuous","It would no longer be a function"],"No, it would not be continuous");
               $notAFunction=PopUp(["?","Yes, it would be continuous","No, it would not be continuous","It would no longer be a function"],"It would no longer be a function");
             </pg-code>
-          </setup>
           <statement>
             <p>
               Use the graph of <m>y=h(x)</m> below to answer the questions that follow.
@@ -1565,13 +1535,11 @@
 
         <exercise>
           <webwork>
-              <setup>
 
             <pg-code>
               $cost=Real(60);
               $units=PopUp(["?","dollars","hours"],"dollars");
             </pg-code>
-              </setup>
               <statement>
                 <p>
                   <em>Tools of the Trade</em> rental shop will rent a pressure washer for <m>\$35</m> for the first two hours,
@@ -1611,7 +1579,6 @@
 
         <exercise>
           <webwork>
-              <setup>
 
             <pg-code>
               $input1=random(5,19,1);
@@ -1621,7 +1588,6 @@
               $output2=Compute("250+($input2-20)*11");
               $input2units=PopUp(["?","dollars","shirts"],"shirts");
             </pg-code>
-              </setup>
               <statement>
                 <p>
                   A T-shirt printer sells custom-printed shirts for
@@ -1685,14 +1651,12 @@
 
         <exercise>
           <webwork>
-              <setup>
 
             <pg-code>
               $height1=Real(0);
               $height2=Real(8);
               $units=PopUp(["?","feet","seconds"],"feet");
             </pg-code>
-              </setup>
               <statement>
                 <p>
                   A tennis ball is dropped from a height of <m>16</m> feet.
@@ -1764,7 +1728,6 @@
 
         <exercise>
           <webwork>
-              <setup>
 
             <pg-code>
               $height1=random(10,15,1);
@@ -1772,7 +1735,6 @@
               $units=PopUp(["?","feet","seconds"],"seconds");
               $time2=Real(2.5);
             </pg-code>
-              </setup>
               <statement>
                 <p>
                   A tennis ball is dropped from a height of <m>16</m> feet.

--- a/src/chapter-exponential-functions.xml
+++ b/src/chapter-exponential-functions.xml
@@ -1670,8 +1670,6 @@
               </ol>
             </p>
           </statement>
-          <solution>
-          </solution>
         </webwork>
       </exercise>
 

--- a/src/chapter-exponential-functions.xml
+++ b/src/chapter-exponential-functions.xml
@@ -885,13 +885,11 @@
 
       <exercise>
         <webwork>
-          <setup>
 
             <pg-code>
               $exponential=PopUp(["?","linear","exponential"],"exponential");
               $linear=PopUp(["?","linear","exponential"],"linear");
             </pg-code>
-          </setup>
           <statement>
             <p>
               For each verbal description, decide if a <em>linear</em> or
@@ -956,13 +954,11 @@
 
       <exercise>
         <webwork>
-          <setup>
 
             <pg-code>
               $isExponential=PopUp(["?","is exponential","is not exponential"],"is exponential");
               $isNotExponential=PopUp(["?","is exponential","is not exponential"],"is not exponential");
             </pg-code>
-          </setup>
           <statement>
             <p>
               Decide if each function below is exponential or not.
@@ -1141,7 +1137,6 @@
 
       <exercise>
         <webwork>
-          <setup>
 
             <pg-code>
               $gr1=init_graph(-2,-2,2,10,axes=>[0,0],grid=>[4,12],size=>[240,240]);
@@ -1155,7 +1150,6 @@
               $gr3 -> lb(new Label (-1.5,7,'C','red','right','top'));
               $whichGraph=PopUp(["?","A","B","C"],"C");
             </pg-code>
-          </setup>
           <statement>
             <p>
               Consider the graphs below:
@@ -1192,7 +1186,6 @@
 
       <exercise>
         <webwork>
-          <setup>
 
             <pg-code>
               $gr1=init_graph(-2,-2,2,10,axes=>[0,0],grid=>[4,12],size=>[240,240]);
@@ -1220,7 +1213,6 @@
               $C=PopUp(["?","A","B","C","D"],"C");
               $D=PopUp(["?","A","B","C","D"],"D");
             </pg-code>
-          </setup>
           <statement>
             <p>
               Consider the graphs below:
@@ -1309,12 +1301,10 @@
 
       <exercise>
         <webwork>
-          <setup>
             <pg-code>
               $yesAsymptote=PopUp(["?","has a horizontal asymptote","does not have a horizontal asymptote"],"has a horizontal asymptote");
               $noAsymptote=PopUp(["?","has a horizontal asymptote","does not have a horizontal asymptote"],"does not have a horizontal asymptote");
             </pg-code>
-          </setup>
           <statement>
             <p>
               Which of the functions below have a horizontal asymptote?
@@ -1421,13 +1411,11 @@
 
       <exercise>
         <webwork>
-          <setup>
             <pg-code>
               $zero=Real(0);
               $three=Real(3);
               $yVar=PopUp(["?","x","y"],"y");
             </pg-code>
-          </setup>
           <statement>
             <p>
               For each function, determine the horizontal asymptote.
@@ -1499,7 +1487,6 @@
 
       <exercise>
         <webwork>
-          <setup>
 
             <pg-code>
               $a=Real(20);
@@ -1509,7 +1496,6 @@
               $increasing=PopUp(["?","increasing","decreasing"],"increasing");
               $decreasing=PopUp(["?","increasing","decreasing"],"decreasing");
             </pg-code>
-          </setup>
           <statement>
             <p>
               In the functions below, the input <m>t</m> represents years. Describe
@@ -1602,13 +1588,11 @@
 
       <exercise>
         <webwork>
-          <setup>
 
             <pg-code>
               $yes=PopUp(["?","yes","no"],"yes");
               $no=PopUp(["?","yes","no"],"no");
             </pg-code>
-          </setup>
           <statement>
             <p>
               Decide if each expression below will <em>increase</em> <m>x</m> by <m>5\%</m>.
@@ -1698,7 +1682,6 @@
 
       <exercise>
         <webwork>
-          <setup>
 
             <pg-code>
               $A=PopUp(["?","A","B","C","D"],"A");
@@ -1706,7 +1689,6 @@
               $C=PopUp(["?","A","B","C","D"],"C");
               $D=PopUp(["?","A","B","C","D"],"D");
             </pg-code>
-          </setup>
           <statement>
             <p>
               Each function below represents the population of a different city,
@@ -1776,14 +1758,12 @@
 
       <exercise>
         <webwork>
-          <setup>
 
             <pg-code>
               Context()->variables->add(t => 'Real');
               $form1=Compute("75*1.046**t");
               $form2=Compute("6.5*0.97**t");
             </pg-code>
-          </setup>
           <statement>
             <p>
               The populations of two cities are described below. For each city, write a
@@ -1986,14 +1966,12 @@
 <!-- application problems -->
         <exercise>
           <webwork>
-              <setup>
 
             <pg-code>
               $bounce=random(3,5,1);
               $formula=Compute("15*0.8**x");
               $height=Compute("15*0.8**$bounce");
             </pg-code>
-              </setup>
               <statement>
                 <p>
                   A ball is dropped from a height of <m>15</m> feet and begins bouncing on the ground.
@@ -2054,7 +2032,6 @@
 
         <exercise>
           <webwork>
-              <setup>
 
             <pg-code>
               $nominal=random(12,25,1)/10;
@@ -2063,7 +2040,6 @@
               $fiveYearGrowthFactor=Compute("(1+$nominal/100)^$years");
               $effectiveRounded=sprintf("%.2f",$effective);
             </pg-code>
-              </setup>
               <statement>
                 <p>
                   An investment grows by <m><var name="$nominal" /> \%</m> each year.
@@ -2111,7 +2087,6 @@
 
         <exercise>
           <webwork>
-              <setup>
 
             <pg-code>
               $lengthPercent=random(3,8,1);
@@ -2120,7 +2095,6 @@
               $effectiveRounded=sprintf("%.2f",$effectiveArea);
               $threeHourGrowthFactor=Compute("(1+$lengthPercent/100)^(2*$hours)");
             </pg-code>
-              </setup>
               <statement>
                 <p>
                   If the side lengths of a square are each increasing by <var name="$lengthPercent" /><m>\%</m> per hour,

--- a/src/chapter-exponential-functions.xml
+++ b/src/chapter-exponential-functions.xml
@@ -964,8 +964,6 @@
               Decide if each function below is exponential or not.
             </p>
 
-            <sidebyside widths="47% 47%">
-
               <tabular top="major" halign="center">
                 <col halign="left" />
                 <col />
@@ -1015,9 +1013,7 @@
                   <cell><m>40</m></cell>
                 </row>
               </tabular>
-            </sidebyside>
 
-            <sidebyside widths="47% 47%">
 
               <tabular top="major" halign="center">
                 <col halign="left" />
@@ -1068,7 +1064,6 @@
                   <cell><m>192</m></cell>
                 </row>
               </tabular>
-            </sidebyside>
 
             <p>
               <ul>
@@ -1155,11 +1150,9 @@
               Consider the graphs below:
             </p>
 
-            <sidebyside widths="30%">
-              <image pg-name="$gr1" />
-              <image pg-name="$gr2" />
-              <image pg-name="$gr3" />
-            </sidebyside>
+            <image pg-name="$gr1" width="30%"/>
+            <image pg-name="$gr2" width="30%"/>
+            <image pg-name="$gr3" width="30%"/>
 
             <p>
               Which could be the graph of <m>f(x)=3^x + 4</m>?
@@ -1218,15 +1211,10 @@
               Consider the graphs below:
             </p>
 
-            <sidebyside widths="40%">
-              <image pg-name="$gr1" />
-              <image pg-name="$gr2" />
-            </sidebyside>
-
-            <sidebyside widths="40%">
-              <image pg-name="$gr3" />
-              <image pg-name="$gr4" />
-            </sidebyside>
+            <image pg-name="$gr1" width="40%"/>
+            <image pg-name="$gr2" width="40%"/>
+            <image pg-name="$gr3" width="40%"/>
+            <image pg-name="$gr4" width="40%"/>
 
             <p>
               Match each formula to its correct graph. You should be able to do this by

--- a/src/chapter-functions.xml
+++ b/src/chapter-functions.xml
@@ -501,7 +501,7 @@
 
       <example>
         <p>
-          The <xref ref="speed-vs-efficiency" text="title">efficiency graph</xref>
+          The <xref ref="speed-vs-efficiency" text="custom">efficiency graph</xref>
           has varying <xref ref="exercise-concavity">concavity</xref>
           depending on what section of inputs we use:
 

--- a/src/chapter-functions.xml
+++ b/src/chapter-functions.xml
@@ -150,7 +150,6 @@
       <exercise>
         <title>Using Function Notation</title>
         <webwork>
-            <setup>
 
             <pg-code>
             Context('Numeric');
@@ -170,7 +169,6 @@
                 displayLabels => 0
             );
             </pg-code>
-            </setup>
             <statement>
               <p>
                 Suppose <m>f</m> is the rule that takes the area of a circle as its input and then outputs the radius of the circle.
@@ -234,7 +232,6 @@
       <exercise>
         <title>Function Notation Application</title>
         <webwork>
-            <setup>
 
             <pg-code>
                 $height=Real(78);
@@ -244,7 +241,6 @@
                 $height2=60;
                 $heightunits=PopUp(["?","inches","feet","none of these"],"inches");
             </pg-code>
-            </setup>
             <statement>
               <p>
                 The function <m>h(y) = 24 + 18y</m> would find the height
@@ -420,7 +416,6 @@
       <exercise>
         <title>Well-Defined</title>
         <webwork>
-            <setup>
 
             <pg-code>
                 $choice = RadioButtons(
@@ -429,7 +424,6 @@
                     displayLabels => 0
                 );
             </pg-code>
-            </setup>
             <statement>
               <p>
                 Suppose <m>f</m> is a function.
@@ -548,12 +542,10 @@
 
       <exercise>
         <webwork>
-            <setup>
 
             <pg-code>
                 $f35 = Real(36.5);
             </pg-code>
-            </setup>
             <statement>
               <p>
                 [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/KuW5Vbqz/width/413/height/331/border/888888" width="413px" height="331px" style="border:0px;" width="431px" height="313px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
@@ -593,13 +585,11 @@
 
       <exercise>
         <webwork>
-            <setup>
 
             <pg-code>
                 $sol1 = Real(45.2);
                 $sol2 = Real(70.4);
             </pg-code>
-            </setup>
             <statement>
               <p>
                 [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/shNZ7dsh/width/413/height/331/border/888888" width="413px" height="331px" style="border:0px;" width="431px" height="313px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
@@ -670,13 +660,11 @@
 
       <exercise>
         <webwork>
-            <setup>
 
             <pg-code>
                 $avrt1 = Real(1.1);
                 $avrt2 = Real(-0.8);
             </pg-code>
-            </setup>
             <statement>
               <p>
                 [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/dGpvT5eC/width/413/height/331/border/888888" width="413px" height="331px" style="border:0px;" width="431px" height="313px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
@@ -830,7 +818,6 @@
             <exercise>
               <title>Name the Units of Average Rate of Change</title>
               <webwork>
-                <setup>
                   <pg-code>
                     $output = RadioButtons(
                     ["psi","feet"],
@@ -845,7 +832,6 @@
                     $numer = Compute("psi");
                     $denom = Compute("ft");
                   </pg-code>
-                </setup>
                 <statement>
                   <p>The units of the output are <var name="$output" form="buttons" /></p>
                   <p>The units of the input are <var name="$input" form="buttons" /></p>
@@ -886,13 +872,11 @@
           </exercise>-->
       <exercise>
         <webwork>
-            <setup>
 
             <pg-code>
               $is=PopUp(["?","Is","Is Not"],"Is Not");
               $isnt=PopUp(["?","Is","Is Not"],"Is");
             </pg-code>
-            </setup>
             <statement>
               <p>
                 Does each equation represent <m>y</m> as a function of <m>x</m>?
@@ -950,13 +934,11 @@
 
       <exercise>
         <webwork>
-            <setup>
 
             <pg-code>
               $solve=PopUp(["?","evaluate f(0)","solve f(x) = 0"],"solve f(x) = 0");
               $evaluate=PopUp(["?","evaluate f(0)","solve f(x) = 0"],"evaluate f(0)");
             </pg-code>
-            </setup>
             <statement>
               <p>
                 Consider the function <m>f(x)=12-3x^2</m>.
@@ -1002,7 +984,6 @@
 
       <exercise>
         <webwork>
-            <setup>
 
             <pg-code>
               $xory1=PopUp(["?","x","y","g(x)"],"x");
@@ -1010,7 +991,6 @@
               $ans1=Real(3/2);
               $ans2=Real(-1);
             </pg-code>
-            </setup>
             <statement>
               <p>
                 Let <m>f(x)=x^2+4x+5</m> and <m>g(x)=2x+4</m>.
@@ -1073,12 +1053,10 @@
 
       <exercise>
         <webwork>
-            <setup>
 
             <pg-code>
               $ans=PopUp(["?","Eight workers painted 7 houses.","It will take 7 workers 8 hours to paint a house.","It will take 8 workers 7 hours to paint a house.","For 8 houses, 7 workers will paint them."],"It will take 8 workers 7 hours to paint a house.");
             </pg-code>
-            </setup>
             <statement>
               <p>
                 Suppose the function <m>h = f(w)</m> represents the hours of labor it will take for <m>w</m> workers to paint a house.
@@ -1112,12 +1090,10 @@
 
       <exercise>
         <webwork>
-            <setup>
 
             <pg-code>
               $ans=PopUp(["?","f(2010) = 2015","f(2015) = 2010"],"f(2010) = 2015");
             </pg-code>
-            </setup>
             <statement>
               <p>
                 Suppose the function <m>p = f(t)</m> represents the population of a certain town,
@@ -1146,14 +1122,12 @@
 
       <exercise>
         <webwork>
-            <setup>
 
             <pg-code>
               $ans1=PopUp(["?","f(8)=8131","f(2018)=8131","f(8131)=2018"],"f(8)=8131");
               $ans2=PopUp(["?","f(2013)","f(3)"],"f(3)");
               $ans3=PopUp(["?","After 8 years, the value has decreased by 13929 dollars.","After 8 years, the value is -13929 dollars."],"After 8 years, the value has decreased by 13929 dollars.");
             </pg-code>
-            </setup>
             <statement>
               <p>
                 A base model <m>2010</m> Ford F-150 had a new list price of <m>\$ 22{,}060</m>.
@@ -1235,13 +1209,11 @@
 
       <exercise>
         <webwork>
-            <setup>
 
             <pg-code>
               $ans1=Real(12);
               $ans2=Real(-1);
             </pg-code>
-            </setup>
             <statement>
               <p>
                 Let <m>g(w) = (w+1)^2+3</m>.
@@ -1304,7 +1276,6 @@
 
       <exercise>
         <webwork>
-            <setup>
 
             <pg-code>
               $aroc_num1=Compute("(400-45)/5");
@@ -1312,7 +1283,6 @@
               $aroc_unit1=PopUp(["?","students","years","students/year","years/student"],"students/year");
               $aroc_unit2=PopUp(["?","teachers","years","years/teacher","teachers/year"],"teachers/year");
             </pg-code>
-            </setup>
             <statement>
               <p>
                 In <m>2012</m> the new school had <m>45</m> students and <m>4</m> teachers,
@@ -1380,7 +1350,6 @@
 
     <exercise>
       <webwork>
-          <setup>
 
             <pg-code>
               $ind1=PopUp(["?","z","t","f"],"f");
@@ -1388,7 +1357,6 @@
               $ind2=PopUp(["?","j","q","J"],"q");
               $dep2=PopUp(["?","j","q","J"],"J");
             </pg-code>
-          </setup>
           <statement>
             <p>
               In each function, determine the independent and dependent variables.
@@ -1460,14 +1428,12 @@
 
     <exercise>
       <webwork>
-          <setup>
 
             <pg-code>
               $f=PopUp(["?","f","g","both f and g","neither function"],"f");
               $g=PopUp(["?","f","g","both f and g","neither function"],"g");
               $both=PopUp(["?","f","g","both f and g","neither function"],"both f and g");
             </pg-code>
-          </setup>
           <statement>
             <p>
               Tables for functions <m>f</m> and <m>g</m> are shown below.
@@ -1640,13 +1606,11 @@
 
     <exercise>
       <webwork>
-          <setup>
 
             <pg-code>
               $stops=Real(2.5);
               $units=PopUp(["?","feet","seconds"],"seconds");
             </pg-code>
-          </setup>
           <statement>
             <p>
               If a ball is held <m>3</m> feet above the ground and kicked straight
@@ -1683,7 +1647,6 @@
 
           <exercise>
             <webwork>
-              <setup>
                 <pg-code>
                   $fof2=Real(4);
                   $solve2=List(-2,0,3);
@@ -1708,7 +1671,6 @@
                   $gr -> lb(new Label (5.5,0.3,'x','black','left','bottom'));
                   $gr -> lb(new Label (0.5,5.5,'y','black','left','bottom'));
                 </pg-code>
-              </setup>
               <statement>
                 <p>The graph below shows the function <m>y=f(x)</m>.</p>
                 <sidebyside widths="40%">
@@ -1818,14 +1780,12 @@
 
           <exercise>
             <webwork>
-              <setup>
                 <pg-code>
                   $aroc_num1=Compute("(400-45)/5");
                   $aroc_num2=Compute("(23-4)/5");
                   $aroc_unit1=PopUp(["?","students","years","students/year","years/student"],"students/year");
                   $aroc_unit2=PopUp(["?","teachers","years","years/teacher","teachers/year"],"teachers/year");
                 </pg-code>
-              </setup>
               <statement>
                 <p>In <m>2012</m> the new school had <m>45</m> students and <m>4</m> teachers, and by <m>2017</m> it had grown to <m>400</m> students and <m>23</m> teachers.</p>
                 <p>Let <m>S = f(y)</m> represent the number of students in the school, and let <m>T = g(y)</m> represent the number of teachers in the school. In both functions, the input variable <m>y</m> represents the number of years after <m>2012</m>.</p>
@@ -1847,13 +1807,11 @@
 
           <exercise>
             <webwork>
-              <setup>
                 <pg-code>
                   $aroc=Real(-2);
                   Context()->variables->are(m=>'Real');
                   $arocm=Formula("m");
                 </pg-code>
-              </setup>
               <statement>
                 <p><ol label="a">
                   <li><p>What is the average rate of change for the function <m>g(x) = -2x + 7</m> on the interval <m>0\leq x \leq 5</m>?</p>
@@ -1876,12 +1834,10 @@
 
           <exercise>
             <webwork>
-              <setup>
                 <pg-code>
                   Context()->variables->are(x=>'Real');
                   $form=Formula("5*x+3");
                 </pg-code>
-              </setup>
               <statement>
                 <p>For a certain linear function <m>f(x)</m>, suppose we know that <m>f(0) = 3</m> and the average rate of change of <m>f</m> is <m>5</m> on the interval <m>1 \leq x \leq 8</m>.</p>
                 <p>Find the formula for the function <m>f(x)</m>.</p>
@@ -1900,7 +1856,6 @@
 
           <exercise>
             <webwork>
-              <setup>
                 <pg-code>
                   $b=random(3,7,1);
                   $c=random(8,12,1);
@@ -1908,7 +1863,6 @@
                   $run=Compute("$b-1");
                   $rise=Compute("5*$run");
                 </pg-code>
-              </setup>
               <statement>
                 <p>Suppose the average rate of change of a function <m>g</m> on the interval <m>1 \leq x \leq <var name="$b" /></m> is <m>5</m>. If <m>g(1) = <var name="$c" /></m>, what is <m>g\left(<var name="$b" />\right)</m>?</p>
                 <p>Answer:  <m>g\left(<var name="$b" />\right) = </m><var name="$d" width="10" /></p>
@@ -1931,12 +1885,10 @@
 
           <exercise>
             <webwork>
-              <setup>
                 <pg-code>
                   $false=PopUp(["?","True","False"],"False");
                   $true=PopUp(["?","True","False"],"True");
                 </pg-code>
-              </setup>
               <statement>
                 <p>True or False:</p>
                 <p><ol label="a">

--- a/src/chapter-functions.xml
+++ b/src/chapter-functions.xml
@@ -1341,12 +1341,11 @@
             </solution>
         </webwork>
       </exercise>
-    </subsection>
 
-    <p>
-      Student Learning Outcome:
-      <em>Determine if a variable is dependent or independent.</em>
-    </p>
+      <p>
+        Student Learning Outcome:
+        <em>Determine if a variable is dependent or independent.</em>
+      </p>
 
     <exercise>
       <webwork>
@@ -2024,5 +2023,6 @@
 
         </exercises>
 -->
+    </subsection>
   </section>
 </chapter>

--- a/src/chapter-functions.xml
+++ b/src/chapter-functions.xml
@@ -813,9 +813,9 @@
         Because slope is just <q>rise over run</q> <mdash /> a fraction,
         the units of the average rate of change are also a fraction.
       </p>
-            <!-- <todo>The exercise below needs context.</todo>
+            <!-- TODO: The exercise below needs context. -->
 
-            <exercise>
+            <!-- <exercise>
               <title>Name the Units of Average Rate of Change</title>
               <webwork>
                   <pg-code>

--- a/src/chapter-functions.xml
+++ b/src/chapter-functions.xml
@@ -1672,9 +1672,7 @@
                 </pg-code>
               <statement>
                 <p>The graph below shows the function <m>y=f(x)</m>.</p>
-                <sidebyside widths="40%">
-                  <image pg-name="$gr" />
-                </sidebyside>
+                <image pg-name="$gr" width="40%"/>
                 <p><ol label="a">
                   <li><p>Evaluate <m>f(2)</m>.</p>
                   <p>Answer:  <m>f(2) = </m><var name="$fof2" width="10" /></p></li>

--- a/src/chapter-functions.xml
+++ b/src/chapter-functions.xml
@@ -1438,107 +1438,103 @@
               Tables for functions <m>f</m> and <m>g</m> are shown below.
             </p>
 
-            <sidebyside widths="47% 47%">
+            <tabular top="major" halign="center">
+              <col halign="left" />
+              <col />
+              <row bottom="medium">
+                <cell><m>x</m></cell>
+                <cell><m>f(x)</m></cell>
+              </row>
+              <row>
+                <cell><m>1</m></cell>
+                <cell><m>12</m></cell>
+              </row>
+              <row>
+                <cell><m>2</m></cell>
+                <cell><m>10</m></cell>
+              </row>
+              <row>
+                <cell><m>3</m></cell>
+                <cell><m>8</m></cell>
+              </row>
+              <row>
+                <cell><m>4</m></cell>
+                <cell><m>6</m></cell>
+              </row>
+              <row>
+                <cell><m>5</m></cell>
+                <cell><m>5</m></cell>
+              </row>
+              <row>
+                <cell><m>6</m></cell>
+                <cell><m>4</m></cell>
+              </row>
+              <row>
+                <cell><m>7</m></cell>
+                <cell><m>5</m></cell>
+              </row>
+              <row>
+                <cell><m>8</m></cell>
+                <cell><m>12</m></cell>
+              </row>
+              <row>
+                <cell><m>9</m></cell>
+                <cell><m>25</m></cell>
+              </row>
+              <row>
+                <cell><m>10</m></cell>
+                <cell><m>119</m></cell>
+              </row>
+            </tabular>
 
-              <tabular top="major" halign="center">
-                <col halign="left" />
-                <col />
-                <row bottom="medium">
-                  <cell><m>x</m></cell>
-                  <cell><m>f(x)</m></cell>
-                </row>
-                <row>
-                  <cell><m>1</m></cell>
-                  <cell><m>12</m></cell>
-                </row>
-                <row>
-                  <cell><m>2</m></cell>
-                  <cell><m>10</m></cell>
-                </row>
-                <row>
-                  <cell><m>3</m></cell>
-                  <cell><m>8</m></cell>
-                </row>
-                <row>
-                  <cell><m>4</m></cell>
-                  <cell><m>6</m></cell>
-                </row>
-                <row>
-                  <cell><m>5</m></cell>
-                  <cell><m>5</m></cell>
-                </row>
-                <row>
-                  <cell><m>6</m></cell>
-                  <cell><m>4</m></cell>
-                </row>
-                <row>
-                  <cell><m>7</m></cell>
-                  <cell><m>5</m></cell>
-                </row>
-                <row>
-                  <cell><m>8</m></cell>
-                  <cell><m>12</m></cell>
-                </row>
-                <row>
-                  <cell><m>9</m></cell>
-                  <cell><m>25</m></cell>
-                </row>
-                <row>
-                  <cell><m>10</m></cell>
-                  <cell><m>119</m></cell>
-                </row>
-              </tabular>
-
-              <tabular top="major" halign="center">
-                <col halign="left" />
-                <col />
-                <row bottom="medium">
-                  <cell><m>x</m></cell>
-                  <cell><m>g(x)</m></cell>
-                </row>
-                <row>
-                  <cell><m>1</m></cell>
-                  <cell><m>45</m></cell>
-                </row>
-                <row>
-                  <cell><m>2</m></cell>
-                  <cell><m>49</m></cell>
-                </row>
-                <row>
-                  <cell><m>3</m></cell>
-                  <cell><m>51</m></cell>
-                </row>
-                <row>
-                  <cell><m>4</m></cell>
-                  <cell><m>53</m></cell>
-                </row>
-                <row>
-                  <cell><m>5</m></cell>
-                  <cell><m>50</m></cell>
-                </row>
-                <row>
-                  <cell><m>6</m></cell>
-                  <cell><m>45</m></cell>
-                </row>
-                <row>
-                  <cell><m>7</m></cell>
-                  <cell><m>40</m></cell>
-                </row>
-                <row>
-                  <cell><m>8</m></cell>
-                  <cell><m>41</m></cell>
-                </row>
-                <row>
-                  <cell><m>9</m></cell>
-                  <cell><m>42</m></cell>
-                </row>
-                <row>
-                  <cell><m>10</m></cell>
-                  <cell><m>44</m></cell>
-                </row>
-              </tabular>
-
-            </sidebyside>
+            <tabular top="major" halign="center">
+              <col halign="left" />
+              <col />
+              <row bottom="medium">
+                <cell><m>x</m></cell>
+                <cell><m>g(x)</m></cell>
+              </row>
+              <row>
+                <cell><m>1</m></cell>
+                <cell><m>45</m></cell>
+              </row>
+              <row>
+                <cell><m>2</m></cell>
+                <cell><m>49</m></cell>
+              </row>
+              <row>
+                <cell><m>3</m></cell>
+                <cell><m>51</m></cell>
+              </row>
+              <row>
+                <cell><m>4</m></cell>
+                <cell><m>53</m></cell>
+              </row>
+              <row>
+                <cell><m>5</m></cell>
+                <cell><m>50</m></cell>
+              </row>
+              <row>
+                <cell><m>6</m></cell>
+                <cell><m>45</m></cell>
+              </row>
+              <row>
+                <cell><m>7</m></cell>
+                <cell><m>40</m></cell>
+              </row>
+              <row>
+                <cell><m>8</m></cell>
+                <cell><m>41</m></cell>
+              </row>
+              <row>
+                <cell><m>9</m></cell>
+                <cell><m>42</m></cell>
+              </row>
+              <row>
+                <cell><m>10</m></cell>
+                <cell><m>44</m></cell>
+              </row>
+            </tabular>
 
             <p>
               <ol label="a">

--- a/src/chapter-logarithmic-functions.xml
+++ b/src/chapter-logarithmic-functions.xml
@@ -2491,14 +2491,14 @@
                 <p>
                   The frequency of a musical tone defines the pitch we hear,
                   which we may give a note value
-                  (such as G or D<hash />).
+                  (such as G or D#).
                   Mathematically, frequency is measured in <em>hertz</em>.
                   A higher number of hertz for a tone means the tone sounds higher.
                 </p>
 
                 <p>
                   On a piano, we have the following notes:
-                  <em>A, A<hash />, B, C, C<hash />, D, D<hash />, E, F, F<hash />, G, G<hash />, A</em>.
+                  <em>A, A#, B, C, C#, D, D#, E, F, F#, G, G#, A</em>.
                   This is called one <em>octave</em> of notes,
                   and these same notes repeat in the next octave
                   (just at higher frequencies).

--- a/src/chapter-logarithmic-functions.xml
+++ b/src/chapter-logarithmic-functions.xml
@@ -793,7 +793,6 @@
         </introduction>
 
         <webwork seed="1">
-            <setup>
 
             <pg-code>
                 $chdrp=random(11,31,1);
@@ -803,7 +802,6 @@
                 $hourlyrate=NumberWithUnits((1-exp(-$chdrp/100))*100,'%/hr');
                 $halflife=NumberWithUnits(ln(0.5)/-$chdrp*100,'hr');
             </pg-code>
-            </setup>
             <stage>
             <statement>
               <p>
@@ -925,7 +923,6 @@
         </introduction>
 
         <webwork seed="1">
-            <setup>
 
             <pg-code>
                 $arp=random(5,15,1);
@@ -935,7 +932,6 @@
                 $contrate=NumberWithUnits(ln(1+$arp/100)*100,'%/yr');
                 $triptime=NumberWithUnits(ln(3)/ln(1+$arp/100),'yr');
             </pg-code>
-            </setup>
             <stage>
             <statement>
               <p>
@@ -1039,7 +1035,6 @@
         </introduction>
 
         <webwork seed="1">
-            <setup>
 
             <pg-code>
                 $doublingdays=random(8,20,1);
@@ -1050,7 +1045,6 @@
                 Context()->variables->are(t=>'Real', P=>'Real');
                 $form=Compute("P*2^(t/$doublingdays)");
             </pg-code>
-            </setup>
             <stage>
             <statement>
               <p>
@@ -1141,7 +1135,6 @@
         </introduction>
 
         <webwork seed="1">
-            <setup>
 
             <pg-code>
                 %hl=('Magnesium-27'=>9.45,'Carbon-11'=>20.33,'Oxygen-15'=>2.04);
@@ -1153,7 +1146,6 @@
                 $time=NumberWithUnits(ln($target/100)/ln(1-ln(2)/$halflifemin),'min');
                 $b=Real(0.5**(1/$halflifemin));
             </pg-code>
-            </setup>
             <stage>
             <statement>
               <p>
@@ -1247,7 +1239,6 @@
         </introduction>
 
         <webwork>
-            <setup>
 
             <pg-code>
                 Context()->variables->are(P=>'Real', t=>'Real');
@@ -1255,7 +1246,6 @@
                 $step=Compute("ln(P/(1-P))");
                 $solution=Compute("e^t/(1+e^t)");
             </pg-code>
-            </setup>
             <stage>
             <statement>
               <p>
@@ -1387,14 +1377,12 @@
 
       <exercise>
         <webwork>
-          <setup>
 
             <pg-code>
               $noneOfThese=PopUp(["?","only f","only g","only h","f and g","f and h","g and j","f, g and h","f, g and j","all of these","none of these"],"none of these");
               $fgj=PopUp(["?","only f","only g","only h","f and g","f and h","g and j","f, g and h","f, g and j","all of these","none of these"],"f, g and j");
               $no=PopUp(["?","yes","no"],"no");
             </pg-code>
-          </setup>
           <statement>
             <p>
               Use the following functions to answer the questions below:
@@ -1458,7 +1446,6 @@
 
       <exercise>
         <webwork>
-          <setup>
 
             <pg-code>
               $gr1=init_graph(-2,-2,12,4,axes=>[0,0],grid=>[14,6],size=>[240,240]);
@@ -1486,7 +1473,6 @@
               $b=PopUp(["?","A","B","C"],"B");
               $c=PopUp(["?","A","B","C"],"C");
             </pg-code>
-          </setup>
           <statement>
             <p>
               Consider the graphs below:
@@ -1561,7 +1547,6 @@
 
       <exercise>
         <webwork>
-          <setup>
 
           <pg-code>
             @x=(1, 10, 100, 1000, 10000);
@@ -1579,7 +1564,6 @@
             @xx=($a/12,$a/12+0.9,$a/12+0.99,$a/12+0.999,$a/12+0.9999);
             @yy=map{($c**2/($_-($a/12+1)))}@xx;
           </pg-code>
-          </setup>
           <statement>
             <p>
               The table below shows values of two functions: <m>y=f(x)</m>
@@ -1690,7 +1674,6 @@
 
       <exercise>
         <webwork>
-          <setup>
 
             <pg-code>
               $a=random(2,6,.1);
@@ -1705,7 +1688,6 @@
               $vAsymptote=PopUp(["?","vertical asymptote","horizontal asymptote"],"vertical asymptote");
               $hAsymptote=PopUp(["?","vertical asymptote","horizontal asymptote"],"horizontal asymptote");
             </pg-code>
-          </setup>
           <statement>
             <p>
               Each function below has either a <em>horizontal</em> or <em>vertical</em>
@@ -1816,14 +1798,12 @@
 
       <exercise>
         <webwork>
-          <setup>
 
             <pg-code>
               $a=list_random(350,400,450,500,550,600,650);
               $b=random(2,9);
               $c=Compute("ln($a)/ln($b)");
             </pg-code>
-          </setup>
           <statement>
             <p>
               Use properties of logarithms to solve for <m>x</m> in the equation
@@ -1849,14 +1829,12 @@
 
       <exercise>
         <webwork>
-          <setup>
 
             <pg-code>
               $a=random(2,7);
               do{$b=random(2,5);}until($b!=$a);
               $c=Compute("($a)**($b)");
             </pg-code>
-          </setup>
           <statement>
             <p>
               Use properties of logarithms to solve for <m>x</m> in the equation
@@ -1881,7 +1859,6 @@
 
       <exercise>
         <webwork>
-          <setup>
 
             <pg-code>
               $T0=Real(165.7);
@@ -1890,7 +1867,6 @@
               $a=random(95,130);
               $time=Compute("ln(($a-65)/100.7)/-0.042");
             </pg-code>
-          </setup>
           <statement>
             <p>
               According to <em>Newton's Law of Cooling</em>, the rate at which
@@ -1987,13 +1963,11 @@
 
       <exercise>
         <webwork>
-          <setup>
 
             <pg-code>
               Context()->variables->are(t=>'Real');
               $formula=Compute("9.624*(1.0192)**t");
             </pg-code>
-          </setup>
           <statement>
             <p>
               According to Wolfram|Alpha, the population of Texas has been
@@ -2230,14 +2204,12 @@
 
         <exercise>
           <webwork>
-              <setup>
 
             <pg-code>
               $digit=random(3,8,1);
               $prob=int(log(2)/log(1+1/$digit)+0.5);
               $rounded=100*sprintf("%.3f",log(1+1/$digit)/log(10));
             </pg-code>
-              </setup>
               <statement>
                 <p>
                   <url href="https://en.wikipedia.org/wiki/Benford%27s_law">Benford's Law</url>
@@ -2283,7 +2255,6 @@
 
         <exercise>
           <webwork>
-              <setup>
 
             <pg-code>
               $percent=random(12,16,1)/10;
@@ -2293,7 +2264,6 @@
               $years=sprintf("%.1f",log(2800/1500)/log(1+$percent/100));
               $t=Compute("log(2800/1500)/log($b)");
             </pg-code>
-              </setup>
               <stage>
               <statement>
                 <p>
@@ -2359,7 +2329,6 @@
 
         <exercise>
           <webwork>
-              <setup>
 
             <pg-code>
               $percent=random(6,9,1);
@@ -2368,7 +2337,6 @@
               $b=Compute("1-$percent/100");
               $years=sprintf("%.1f",log(0.5)/log($b));
             </pg-code>
-              </setup>
               <stage>
               <statement>
                 <p>
@@ -2435,13 +2403,11 @@
 
         <exercise>
           <webwork>
-              <setup>
 
             <pg-code>
               $bRounded=sprintf("%.2f",4/(log(9)/log(2)));
               $options=Real(26);
             </pg-code>
-              </setup>
               <stage>
               <statement>
                 <p>
@@ -2517,12 +2483,10 @@
 
         <exercise>
           <webwork>
-              <setup>
 
             <pg-code>
               $note=PopUp(["?","A","B","C","D","E","F"],"C");
             </pg-code>
-              </setup>
               <statement>
                 <p>
                   The frequency of a musical tone defines the pitch we hear,
@@ -2589,7 +2553,6 @@
 
         <exercise>
           <webwork>
-              <setup>
 
             <pg-code>
               @people=(30,38,41,49,57,68);
@@ -2598,7 +2561,6 @@
               $rejected=$choices/2.718281828459045;
               $rejectedRounded=sprintf("%.0f",$rejected);
             </pg-code>
-              </setup>
               <statement>
                 <p>
                   A famous application involving the number <m>e</m> comes from
@@ -2705,14 +2667,12 @@
 
         <exercise>
           <webwork>
-              <setup>
 
             <pg-code>
               $rate=random(3,8,1)/100;
               $initial=random(3,7,1)*1000;
               $years=Compute("ln(2)/$rate");
             </pg-code>
-              </setup>
               <statement>
                 <p>
                   Suppose a population is given by
@@ -2748,14 +2708,12 @@
 
         <exercise>
           <webwork>
-              <setup>
 
             <pg-code>
               $rateF=random(6,9,1);
               $rateG=random(3,5,1);
               $solution=Compute("ln(450/700)/ln((1+$rateG/100)/(1+$rateF/100))");
             </pg-code>
-              </setup>
               <statement>
                 <p>
                   Suppose <m>f(t)</m> has an initial value of <m>450</m> and increases by <var name="$rateF" /> <m>\%</m> per year,
@@ -2784,14 +2742,12 @@
 
         <exercise>
           <webwork>
-              <setup>
 
             <pg-code>
               $rate=random(55,75,1)/10;
               $initial=random(55,85,1)*100;
               $k=Compute("ln(1+$rate/100)");
             </pg-code>
-              </setup>
               <statement>
                 <p>
                   The value of an asset is increasing by <var name="$rate" /><m>\%</m> per year and has an intial value of <m>\$</m><var name="$initial" />.
@@ -2834,13 +2790,11 @@
 
         <exercise>
           <webwork>
-              <setup>
 
             <pg-code>
               $left=random(30,50,1);
               $k=Compute("ln($left/100)/1000");
             </pg-code>
-              </setup>
               <statement>
                 <p>
                   Suppose a value is decaying,
@@ -2874,7 +2828,6 @@
 <!-- This problem returns the error: Can't generate enough valid points for comparison
       <exercise>
         <webwork>
-          <setup>
             <pg-code>
               $a=random(19,35,1)*100;
               $b=random(3,9,1)/100;
@@ -2883,7 +2836,6 @@
               Context()->variables->set(x=>{limits=>[40.01,40.99]});
               $inverse=Compute("ln((x-$c)/$a)/$b");
             </pg-code>
-          </setup>
           <statement>
             <p>
               Determine a formula for the inverse function of <m>f(x) = <var name="$a" />e^{<var name="$b" />x} + <var name="$c" /></m>.
@@ -2902,7 +2854,6 @@
 -->
         <exercise>
           <webwork>
-              <setup>
 
             <pg-code>
               $halfLife=random(25,45,1);
@@ -2911,7 +2862,6 @@
               $formula=Compute("$initial*(0.5)^(t/$halfLife)");
               $hours=Compute("ln(10/$initial)/ln(0.5)*$halfLife");
             </pg-code>
-              </setup>
               <statement>
                 <p>
                   A highly unstable element has a half-life of <var name="$halfLife" /> hours.
@@ -2972,7 +2922,6 @@
 
         <exercise>
           <webwork>
-              <setup>
 
             <pg-code>
               $cells=Compute("10^6*e^(0.495105)");
@@ -2980,7 +2929,6 @@
               $true=PopUp(["?","True","False"],"True");
               $concern=PopUp(["?","Yes, because her equation is different from yours.","No, because your formulas are equivalent."],"No, because your formulas are equivalent.");
             </pg-code>
-              </setup>
               <statement>
                 <p>
                   A colony of yeast cells is estimated to contain <m>10^6</m> cells at time <m>t = 0</m>.

--- a/src/chapter-logarithmic-functions.xml
+++ b/src/chapter-logarithmic-functions.xml
@@ -573,8 +573,6 @@
             The answer (output) is the <m>y</m>-value.
           </p>
 
-          <sidebyside>
-
             <tabular top="medium" bottom="medium" left="medium" right="medium">
               <col halign="center"/>
               <col halign="center"/>
@@ -615,8 +613,6 @@
                 <cell>Because <m>3^{2}=9</m></cell>
               </row>
             </tabular>
-
-          </sidebyside>
 
           <p>
             For inputs between zero and one,
@@ -1478,15 +1474,10 @@
               Consider the graphs below:
             </p>
 
-            <sidebyside widths="35%">
-              <image pg-name="$gr1" />
-              <image pg-name="$gr2" />
-            </sidebyside>
-
-            <sidebyside widths="35%">
-              <image pg-name="$gr3" />
-              <image pg-name="$gr4" />
-            </sidebyside>
+            <image pg-name="$gr1" width="35%"/>
+            <image pg-name="$gr2" width="35%"/>
+            <image pg-name="$gr3" width="35%"/>
+            <image pg-name="$gr4" width="35%"/>
 
             <p>
               <ul>
@@ -1570,8 +1561,6 @@
               and <m>y=g(x)</m>
             </p>
 
-            <sidebyside>
-
               <tabular top="major" halign="center">
                 <col halign="left" />
                 <col halign="left" />
@@ -1629,8 +1618,6 @@
                   <cell><m><var name="$yy[4]" /></m></cell>
                 </row>
               </tabular>
-
-            </sidebyside>
 
             <p>
               <ol label="a">

--- a/src/chapter-power-functions-and-polynomials.xml
+++ b/src/chapter-power-functions-and-polynomials.xml
@@ -721,7 +721,7 @@
         off of the <m>x</m>-axis at the root.
       </p>
 
-      <todo>Insert a graph here.</todo>
+      <!-- TODO: Insert a graph here. -->
 
       <p>
         This phenomenon of <em>bouncing</em>
@@ -732,7 +732,7 @@
         </me>
       </p>
 
-      <todo>Fix the following graph, then learn how to make graphs that aren't disgusting</todo>
+      <!-- TODO: Fix the following graph, then learn how to make graphs that aren't disgusting -->
 
       <figure>
         <caption><m>y = (x+3)^2(x-1)</m></caption>

--- a/src/chapter-power-functions-and-polynomials.xml
+++ b/src/chapter-power-functions-and-polynomials.xml
@@ -1365,13 +1365,13 @@
         </exercise> -->
       </exercisegroup>
 <!-- application problems -->
-      <exercisegroup>
+      <!-- <exercisegroup>
 
         <introduction>
           <p>
             Additional Problems
           </p>
-        </introduction>
+        </introduction> -->
 
 <!-- The following problem does not use BEGIN_TEXT or BEGIN_PGML -->
 <!-- Not currently compatible with PTX (2/11/2019)               -->
@@ -1379,7 +1379,7 @@
           <webwork source="Library/Rochester/setAlgebra23PolynomialZeros/beth1polydiv.pg" seed="1" />
         </exercise> -->
 
-      </exercisegroup>
+      <!-- </exercisegroup> -->
     </exercises>
   </section>
 

--- a/src/chapter-power-functions-and-polynomials.xml
+++ b/src/chapter-power-functions-and-polynomials.xml
@@ -820,7 +820,6 @@
 
       <exercise>
         <webwork>
-            <setup>
 
             <pg-code>
               $formulaOptions = RadioButtons(
@@ -829,7 +828,6 @@
                 displayLabels => 0
               );
             </pg-code>
-            </setup>
             <statement>
               <p>
                 The graph below shows a polynomial <m>y = f(x)</m>.
@@ -1017,11 +1015,9 @@
 
       <exercise>
         <webwork>
-            <setup>
 
             <pg-code>
             </pg-code>
-            </setup>
             <statement>
               <p>
                 In this problem,

--- a/src/chapter-reflections-and-vertical-stretches.xml
+++ b/src/chapter-reflections-and-vertical-stretches.xml
@@ -1119,9 +1119,7 @@
               The graph of the function <m>y=f(x)</m> is shown below.
             </p>
 
-            <p>
-              <image pg-name="$gr" />
-            </p>
+            <image pg-name="$gr" />
 
             <p>
               Four transformations of <m>y = f(x)</m> are shown. Use them to

--- a/src/chapter-reflections-and-vertical-stretches.xml
+++ b/src/chapter-reflections-and-vertical-stretches.xml
@@ -224,7 +224,6 @@
 
       <exercise>
         <webwork>
-            <setup>
 
             <pg-code>
               $description1=PopUp(["?","horizontal axis","vertical axis"],"vertical axis");
@@ -239,7 +238,6 @@
 
               $nMinusC=Compute("x-$c");
             </pg-code>
-            </setup>
             <statement>
               <p>
                 Let <m>m(x) = x^2 - <var name="$a" />x + <var name="$b" /></m>.
@@ -883,7 +881,6 @@
 
       <exercise>
         <webwork>
-          <setup>
 
             <pg-code>
               $xAxis=PopUp(["?","over the x-axis","over the y-axis","over nothing"],"over the x-axis");
@@ -891,7 +888,6 @@
               $left=PopUp(["?","up","down","right","left"],"left");
               $up=PopUp(["?","up","down","right","left"],"up");
             </pg-code>
-          </setup>
           <statement>
             <p>
               Describe how the graph of the original function <m>y=f(x)</m>
@@ -954,7 +950,6 @@
 
       <exercise>
         <webwork>
-          <setup>
 
             <pg-code>
               $gr=init_graph(-3,-7,11,7,axes=>[0,0],grid=>[14,14],size=>[240,240]);
@@ -967,7 +962,6 @@
 
               $k=Real(-2);
             </pg-code>
-          </setup>
           <statement>
             <p>
               A function <m>y = f(x)</m> is graphed below, together with a transformation
@@ -1007,13 +1001,11 @@
 
       <exercise>
         <webwork>
-          <setup>
 
             <pg-code>
               $yAxis=PopUp(["?","Reflect it over the x-axis","Reflect it over the y-axis"],"Reflect it over the y-axis");
               $xAxis=PopUp(["?","Reflect it over the x-axis","Reflect it over the y-axis"],"Reflect it over the x-axis");
             </pg-code>
-          </setup>
           <statement>
             <p>
               Think about the graph of any function <m>y = f(x)</m>.
@@ -1072,7 +1064,6 @@
 
       <exercise>
         <webwork>
-          <setup>
 
             <pg-code>
               $gr=init_graph(-5,-10,5,10,axes=>[0,0],grid=>[10,20],size=>[240,240]);
@@ -1123,7 +1114,6 @@
               $C=PopUp(["?","A","B","C","D"],"C");
               $D=PopUp(["?","A","B","C","D"],"D");
             </pg-code>
-          </setup>
           <statement>
             <p>
               The graph of the function <m>y=f(x)</m> is shown below.
@@ -1204,7 +1194,6 @@
 
       <exercise>
         <webwork>
-          <setup>
 
             <pg-code>
               $a=random(3,12,1);
@@ -1225,7 +1214,6 @@
               $formula4=Formula("f(-x)+$e");
               $formula5=Formula("-$g*f(x+$f)");
             </pg-code>
-          </setup>
           <statement>
             <p>
               In this problem, you will use an arbitrary function <m>f(x)</m>. Write

--- a/src/chapter-reflections-and-vertical-stretches.xml
+++ b/src/chapter-reflections-and-vertical-stretches.xml
@@ -856,12 +856,12 @@
         </solution>
       </example>
 
-      <todo>
+      <!-- TODO:
         Nick, write an exercise wherein the user writes the equation for a
         vertical stretch or compression of a given function, so its graph passes
         through a given point. If their graph passes through the point but is
         not a vertical stretch or compression, give appropriate feedback.
-      </todo>
+      -->
 
     </subsection>
 

--- a/src/chapter-reflections-and-vertical-stretches.xml
+++ b/src/chapter-reflections-and-vertical-stretches.xml
@@ -968,10 +968,8 @@
               <m>y = g(x)</m>.
             </p>
 
-            <sidebyside widths="40%">
-              <image pg-name="$gr" />
-              <image pg-name="$gr1" />
-            </sidebyside>
+            <image pg-name="$gr" width="40%"/>
+            <image pg-name="$gr1" width="40%"/>
 
             <p>
               Suppose <m>g(x) = k\cdot f(x)</m> for some constant number <m>k</m>.
@@ -1126,15 +1124,10 @@
               answer the questions that follow.
             </p>
 
-            <sidebyside widths="40%">
-              <image pg-name="$gr1" />
-              <image pg-name="$gr2" />
-            </sidebyside>
-
-            <sidebyside widths="40%">
-              <image pg-name="$gr3" />
-              <image pg-name="$gr4" />
-            </sidebyside>
+            <image pg-name="$gr1" width="40%"/>
+            <image pg-name="$gr2" width="40%"/>
+            <image pg-name="$gr3" width="40%"/>
+            <image pg-name="$gr4" width="40%"/>
 
             <p>
               <ul>

--- a/src/chapter-vertical-and-horizontal-translations.xml
+++ b/src/chapter-vertical-and-horizontal-translations.xml
@@ -915,9 +915,7 @@
               The graph <m>y=f(x)=x^3</m> is graphed below.
             </p>
 
-            <p>
-              <image pg-name="$gr" />
-            </p>
+            <image pg-name="$gr" />
 
             <p>
               Below are shown four translations of <m>f(x)</m>. Answer the
@@ -1059,9 +1057,7 @@
               The graph <m>y=f(x)=x^3</m> is graphed below.
             </p>
 
-            <p>
-              <image pg-name="$gr" />
-            </p>
+            <image pg-name="$gr" />
 
             <p>
               Below are shown four translations of <m>f(x)</m>. Answer the
@@ -1185,9 +1181,7 @@
               The graph of a function <m>y = g(x)</m> is shown below.
             </p>
 
-            <p>
-              <image pg-name="$gr" />
-            </p>
+            <image pg-name="$gr" />
 
             <p>
               <ol label ="a">

--- a/src/chapter-vertical-and-horizontal-translations.xml
+++ b/src/chapter-vertical-and-horizontal-translations.xml
@@ -36,6 +36,8 @@
 
   <section xml:id="vertical-and-horizontal-translations-gist">
     <title>Gist of Vertical and Horizontal Translations</title>
+    <subsection>
+      <title>Introduction</title>
     <p>
       To <term>transform</term> a function means to change it <mdash /> either its <term>input</term>
       or its <term>output</term>.
@@ -836,6 +838,7 @@
           </solution>
       </webwork>
     </exercise>
+    </subsection>
 
     <subsection>
       <title>Conclusion</title>

--- a/src/chapter-vertical-and-horizontal-translations.xml
+++ b/src/chapter-vertical-and-horizontal-translations.xml
@@ -922,15 +922,10 @@
               questions that follow.
             </p>
 
-            <sidebyside widths="40%">
-              <image pg-name="$gr1" />
-              <image pg-name="$gr2" />
-            </sidebyside>
-
-            <sidebyside widths="40%">
-              <image pg-name="$gr3" />
-              <image pg-name="$gr4" />
-            </sidebyside>
+            <image pg-name="$gr1" width="40%"/>
+            <image pg-name="$gr2" width="40%"/>
+            <image pg-name="$gr3" width="40%"/>
+            <image pg-name="$gr4" width="40%"/>
 
             <p>
               <ul>
@@ -1064,15 +1059,10 @@
               questions that follow.
             </p>
 
-            <sidebyside widths="40%">
-              <image pg-name="$gr1" />
-              <image pg-name="$gr2" />
-            </sidebyside>
-
-            <sidebyside widths="40%">
-              <image pg-name="$gr3" />
-              <image pg-name="$gr4" />
-            </sidebyside>
+            <image pg-name="$gr1" width="40%"/>
+            <image pg-name="$gr2" width="40%"/>
+            <image pg-name="$gr3" width="40%"/>
+            <image pg-name="$gr4" width="40%"/>
 
             <p>
               <ul>

--- a/src/chapter-vertical-and-horizontal-translations.xml
+++ b/src/chapter-vertical-and-horizontal-translations.xml
@@ -78,13 +78,11 @@
     -->
     <exercise>
       <webwork>
-          <setup>
 
             <pg-code>
                 $eqn1=Compute("(x-3)^2-5(x-3)");
                 $eqn2=Compute("x^2-5x+4");
             </pg-code>
-          </setup>
           <statement>
             <p>
               Given the function <m>f(x) = x^2 - 5x</m>,
@@ -163,13 +161,11 @@
 
     <exercise>
       <webwork>
-          <setup>
 
             <pg-code>
                 $neg=PopUp(["?","positive","negative"],2);
                 $pos=PopUp(["?","positive","negative"],1);
             </pg-code>
-          </setup>
           <statement>
             <p>
               [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/paqqv23d/width/438/height/474/border/888888/smb/false/stb/false/stbh/false/ai/false/asb/false/sri/true/rc/false/ld/false/sdz/false/ctl/false" width="438px" height="474px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
@@ -506,7 +502,6 @@
 
     <exercise>
       <webwork>
-          <setup>
 
             <pg-code>
                 $h1 = Real(random(1, 9, 1));
@@ -516,7 +511,6 @@
                 $f = Compute("(x - $h1)^2 + $k1");
                 $g = Compute("(x - $h2)^2 + $k2");
             </pg-code>
-          </setup>
           <statement>
             <p>
               <ol label="a">
@@ -569,7 +563,6 @@
 
     <exercise>
       <webwork>
-          <setup>
 
             <pg-code>
                 Context('Numeric');
@@ -579,7 +572,6 @@
                     displayLabels => 0
                 );
             </pg-code>
-          </setup>
           <statement>
             <p>
               The dashed green graph below shows <m>f(x) = x^2 - \sqrt{x}</m>.
@@ -642,7 +634,6 @@
 
     <exercise>
       <webwork>
-          <setup>
 
             <pg-code>
                 $formula2 = RadioButtons(
@@ -651,7 +642,6 @@
                     displayLabels => 0
                 );
             </pg-code>
-          </setup>
           <statement>
             <p>
               The dashed green graph below shows <m>f(x) = 5\left\lvert x\right\rvert - x^2</m>.
@@ -758,7 +748,6 @@
 
     <exercise>
       <webwork>
-          <setup>
 
             <pg-code>
                 $first=PopUp(
@@ -768,7 +757,6 @@
                 ["?","T(d + 14) + 5","T(d - 14) + 5","T(d + 14) - 5","T(d - 14) - 5"],"T(d - 14) + 5"
                 );
             </pg-code>
-          </setup>
           <statement>
             <p>
               Suppose this is the first week of the year,
@@ -865,7 +853,6 @@
 
       <exercise>
         <webwork>
-          <setup>
 
             <pg-code>
               $gr=init_graph(-6,-30,6,30,axes=>[0,0],grid=>[12,12],size=>[240,240]);
@@ -920,7 +907,6 @@
               $cOnly=PopUp(["?","A only","B only","C only","D only","A and B","A and C","B and D","C and D","A,B,C and D","None of the graphs"],"C only");
               $bAndD=PopUp(["?","A only","B only","C only","D only","A and B","A and C","B and D","C and D","A,B,C and D","None of the graphs"],"B and D");
             </pg-code>
-          </setup>
           <statement>
             <p>
               The graph <m>y=f(x)=x^3</m> is graphed below.
@@ -1009,7 +995,6 @@
 
       <exercise>
         <webwork>
-          <setup>
 
             <pg-code>
               $gr=init_graph(-6,-30,6,30,axes=>[0,0],grid=>[12,12],size=>[240,240]);
@@ -1066,7 +1051,6 @@
               $cFormula=Compute("x**3-5");
               $dFormula=Compute("(x+1)**3-2");
             </pg-code>
-          </setup>
           <statement>
             <p>
               The graph <m>y=f(x)=x^3</m> is graphed below.
@@ -1176,7 +1160,6 @@
 
       <exercise>
         <webwork>
-          <setup>
 
             <pg-code>
               $gr=init_graph(-8,-8,8,8,axes=>[0,0],grid=>[16,16],size=>[240,240]);
@@ -1194,7 +1177,6 @@
               $xVar=PopUp(["?","x","y"],"x");
               $yVar=PopUp(["?","x","y"],"y");
             </pg-code>
-          </setup>
           <statement>
             <p>
               The graph of a function <m>y = g(x)</m> is shown below.
@@ -1270,7 +1252,6 @@
 
       <exercise>
         <webwork>
-          <setup>
 
             <pg-code>
               @a=map{2*$_+3}NchooseK(7,3);
@@ -1278,7 +1259,6 @@
               $form1=PopUp(["?","$a[0](x-$a[1])+$a[2]","$a[1](x-$a[2])+$a[0]","$a[2](x-$a[1])+$a[0]"],"$a[0](x-$a[1])+$a[2]");
               $form2=PopUp(["?","$b[1](x-$b[2])+$b[0]","$b[1](x-$b[0])+$b[2]","$b[0](x-$b[1])+$b[2]"],"$b[0](x-$b[1])+$b[2]");
             </pg-code>
-          </setup>
           <statement>
             <p>
               Use horizontal and/or vertical translations to choose the correct
@@ -1339,7 +1319,6 @@
 
       <exercise>
         <webwork>
-          <setup>
 
             <pg-code>
               @a=map{2*$_+3}NchooseK(7,3);
@@ -1347,7 +1326,6 @@
               $form1=Compute("$a[0]*(x-$a[1])+$a[2]");
               $form2=Compute("$b[0]*(x-$b[1])+$b[2]");
             </pg-code>
-          </setup>
           <statement>
             <p>
               Use horizontal and/or vertical translations to choose the correct
@@ -1412,7 +1390,6 @@
 
       <exercise>
         <webwork>
-            <setup>
 
             <pg-code>
               Context('Numeric');
@@ -1425,7 +1402,6 @@
                 ["?","Input","Output"],"Input"
               );
             </pg-code>
-            </setup>
             <statement>
               <p>
                 The function <m>h(t) = -4.9t^2 + 10t + 40</m> will approximate the height of an object which was thrown straight upward at a speed of 10 meters per second at time <m>t = 0</m> seconds from a height of 40 meters.
@@ -1514,7 +1490,6 @@
 
       <exercise>
         <webwork>
-            <setup>
 
             <pg-code>
               Context()->variables->are(t=>'Real');
@@ -1522,7 +1497,6 @@
               $addOrSubtract=PopUp(["?","add","subtract"],"add");
               $outputChange=Real(12);
             </pg-code>
-            </setup>
             <statement>
               <p>
                 Again, the function <m>f(t) = -4.9t^2 + 10t + 40</m> represents the height of an object which was thrown straight upward at a speed of 10 meters per second,

--- a/src/frontmatter.xml
+++ b/src/frontmatter.xml
@@ -9,7 +9,7 @@
 ##                                                                       ##
 ## ********************************************************************* ##
 -->
-<frontmatter xml:id="index" xmlns:xi="http://www.w3.org/2001/XInclude">
+<frontmatter xml:id="frontmatter" xmlns:xi="http://www.w3.org/2001/XInclude">
 
   <titlepage>
 

--- a/src/precalc1-MHCC.xml
+++ b/src/precalc1-MHCC.xml
@@ -9,7 +9,7 @@
 ##                                                                       ##
 ## ********************************************************************* ##
 -->
-<mathbook xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en-US">
+<pretext xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en-US">
   <xi:include href="./bookinfo.xml" /> <!-- ISBN, website, other metadata -->
   <book xml:id="precalc1-MHCC">
     <title>Precalculus: An Active Reading Approach</title>
@@ -29,4 +29,4 @@
     <!-- <xi:include href="./sandbox.xml" /> -->
     <xi:include href="./backmatter.xml" />
   </book>
-</mathbook>
+</pretext>

--- a/src/precalc1-MHCC.xml
+++ b/src/precalc1-MHCC.xml
@@ -14,7 +14,7 @@
   <book xml:id="precalc1-MHCC">
     <title>Precalculus: An Active Reading Approach</title>
     <subtitle>Elementary Functions</subtitle>
-    Title Page, Preface, etc.
+    <!-- Title Page, Preface, etc. -->
     <xi:include href="./frontmatter.xml" />
     <xi:include href="./chapter-functions.xml" />
     <xi:include href="./chapter-domain-and-range-piecewise.xml" />

--- a/src/projects-function-notation.xml
+++ b/src/projects-function-notation.xml
@@ -12,9 +12,11 @@
 <section xml:id="projects-function-notation" xmlns:xi="http://www.w3.org/2001/XInclude">
   <title>Projects: Functions and Notation</title>
   <introduction>
-    Show all your work when algebra is necessary or when making calculations.
-    If reading a graph or table, briefly explain how you used the graph or the table
-    to arrive at your answer.
+    <p>
+      Show all your work when algebra is necessary or when making calculations.
+      If reading a graph or table, briefly explain how you used the graph or the table
+      to arrive at your answer.
+    </p>
   </introduction>
 
   <exercises>

--- a/src/projects-function-notation.xml
+++ b/src/projects-function-notation.xml
@@ -126,26 +126,22 @@
                 <p>
                   Match each expression to the correct phrase:
                 </p>
-                <statement>
-                  <figure>
-                    <tabular top="medium" bottom="medium" left="medium" right="medium">
-                      <col halign="center"/>
-                      <col halign="center"/>
-                      <row>
-                        <cell><m>A(3r)</m></cell>
-                        <cell>The surface area of three cans of radius <m>r</m></cell>
-                      </row>
-                      <row>
-                        <cell><m>3A(r)</m></cell>
-                        <cell>The surface area of a can of radius <m>r</m>, then add on <m>3</m> more square inches</cell>
-                      </row>
-                      <row>
-                        <cell><m>A(r)+3</m></cell>
-                        <cell>The surface area of a can whose radius is <m>3</m> times as large as <m>r</m></cell>
-                      </row>
-                    </tabular>
-                  </figure>
-                </statement>
+                <tabular top="medium" bottom="medium" left="medium" right="medium">
+                  <col halign="center"/>
+                  <col halign="center"/>
+                  <row>
+                    <cell><m>A(3r)</m></cell>
+                    <cell>The surface area of three cans of radius <m>r</m></cell>
+                  </row>
+                  <row>
+                    <cell><m>3A(r)</m></cell>
+                    <cell>The surface area of a can of radius <m>r</m>, then add on <m>3</m> more square inches</cell>
+                  </row>
+                  <row>
+                    <cell><m>A(r)+3</m></cell>
+                    <cell>The surface area of a can whose radius is <m>3</m> times as large as <m>r</m></cell>
+                  </row>
+                </tabular>
               </li>
             </ol>
           </p>

--- a/src/projects-function-notation.xml
+++ b/src/projects-function-notation.xml
@@ -24,7 +24,7 @@
         <exercise>
         <statement>
           <p>
-            The graph in the figure models the amount of drug, <m>A(t)</m> <init>mg</init>, in a patient’s body after ingestion as a function of time, <m>t</m> hours.  The body absorbs the drug at a linear rate, but then eliminates the drug at an exponential rate  
+            The graph in the figure models the amount of drug, <m>A(t)</m> <init>mg</init>, in a patient’s body after ingestion as a function of time, <m>t</m> hours.  The body absorbs the drug at a linear rate, but then eliminates the drug at an exponential rate
           </p>
           <p>
             <ol label="a">
@@ -45,7 +45,7 @@
               </li>
               <li>
                 <p>
-                  Calculate  on the interval <m>\frac{\Delta A}{\Delta t}</m> on the interval <m>3 \leq x \leq 6</m>.  Show your work.  
+                  Calculate  on the interval <m>\frac{\Delta A}{\Delta t}</m> on the interval <m>3 \leq x \leq 6</m>.  Show your work.
                 </p>
               </li>
               <li>
@@ -147,7 +147,7 @@
           </p>
         </statement>
       </exercise>
-      
+
       <exercise>
         <statement>
           <p>
@@ -335,7 +335,7 @@
           </p>
         </statement>
       </exercise>
-      
+
       <exercise>
         <statement>
           <p>
@@ -651,12 +651,12 @@
         </statement>
       </exercise>
 
-      
+
     </subexercises>
 
     <subexercises>
       <title>Maintain and strengthen prerequisites, especially: percent, linear and quadratic functions, solving equations.</title>
-      
+
       <exercise>
         <statement>
           <p>
@@ -899,7 +899,7 @@
         </statement>
       </exercise>
 
-      
+
     </subexercises>
 
     <subexercises>
@@ -1048,10 +1048,10 @@
                </ul>
              </p>
           <p>
-            Under these conditions, you may wonder how to actually choose the best person for the job. If you choose a good candidate early on, you may miss the opportunity to hire a really great candidate later. If you wait too long, you may only be left with mediocre candidates from which to choose. 
+            Under these conditions, you may wonder how to actually choose the best person for the job. If you choose a good candidate early on, you may miss the opportunity to hire a really great candidate later. If you wait too long, you may only be left with mediocre candidates from which to choose.
           </p>
           <p>
-            The solution is to interview the first <m>\frac{n}/{e}</m> candidates but reject all of them, regardless of their qualifications. Then, continue interviewing candidates until you find the first one that is “better” than the first group you rejected. Then hire this person. 
+            The solution is to interview the first <m>\frac{n}/{e}</m> candidates but reject all of them, regardless of their qualifications. Then, continue interviewing candidates until you find the first one that is “better” than the first group you rejected. Then hire this person.
           </p>
           <p>
             Interestingly, this simple rule has been shown to find the best candidate in a group approximately 37% of the time, no matter the size of the group!
@@ -1063,13 +1063,13 @@
             Suppose a group of people line up to be chosen as an extra in a movie. The casting director only has time to interview people one at a time and make a decision - yes or no. Suppose the casting director is familiar with the Best Choice Problem, and she interviews and rejects the first 25 people in line. How many people are in line? Round your answer to the closest whole number.
           </p>
         </statement>
-      </exercise> 
+      </exercise>
 
     </subexercises> -->
 
     <!-- <subexercises>
       <title>Horizontal and Vertical Translations</title>
-      
+
 
     </subexercises> -->
 
@@ -1346,7 +1346,7 @@
       <title>
         Use the characteristics of basic functions (linear, constant, polynomial, exponential, logarithmic, power, piece-wise), especially slope, intercepts, rate of change, percent change and average change, to answer questions in application situations, to write equations and to create graphs by hand and on the calculator.
       </title>
-      
+
         <exercise>
         <statement>
           <p>
@@ -1359,7 +1359,7 @@
                 </p>
               </li>
               <li>
-                <p>Find an exponential formula, <m>E(t)</m>,  that models the amount of drug, <init>mg</init>, in the patient’s body as a function of time, <m>t</m> hours after <m>10</m> <init>a.m.</init> 
+                <p>Find an exponential formula, <m>E(t)</m>,  that models the amount of drug, <init>mg</init>, in the patient’s body as a function of time, <m>t</m> hours after <m>10</m> <init>a.m.</init>
                 </p>
               </li>
               <li>
@@ -1380,7 +1380,7 @@
               </li>
               <li>
                 <p>
-                  Use your exponential equation to calculate the half-life of the drug in the body. 
+                  Use your exponential equation to calculate the half-life of the drug in the body.
                 </p>
               </li>
               <li>
@@ -1532,7 +1532,7 @@
           </p>
         </statement>
       </exercise>
-      
+
       <exercise>
         <statement>
           <p>

--- a/src/projects-function-notation.xml
+++ b/src/projects-function-notation.xml
@@ -1016,9 +1016,9 @@
 
     </subexercises>
 
-    <subexercises>
+    <!-- <subexercises>
       <title>Solve equations algebraically using properties of exponents and logarithms</title>
-<!--       <exercise>
+       <exercise>
         <statement>
           <p>
             A famous application involving the number <m>e</m> comes from Optimal Stopping  theory. Known as the Best Choice Problem, it concerns hiring someone for a job under the following conditions:
@@ -1063,9 +1063,9 @@
             Suppose a group of people line up to be chosen as an extra in a movie. The casting director only has time to interview people one at a time and make a decision - yes or no. Suppose the casting director is familiar with the Best Choice Problem, and she interviews and rejects the first 25 people in line. How many people are in line? Round your answer to the closest whole number.
           </p>
         </statement>
-      </exercise> -->
+      </exercise> 
 
-    </subexercises>
+    </subexercises> -->
 
     <!-- <subexercises>
       <title>Horizontal and Vertical Translations</title>

--- a/src/projects-function-notation.xml
+++ b/src/projects-function-notation.xml
@@ -55,35 +55,33 @@
               </li>
             </ol>
           </p>
-          <sidebyside widths="47%">
-            <image>
-              <description>
-                Interpreting function notation from a graph.
-              </description>
-              <latex-image>
-                \begin{tikzpicture}
-                \begin{axis}[
-                  xmin=-1,
-                  xmax=20,
-                  ymin=-0.2,
-                  ymax=215,
-                  grid=both,
-                  xtick={5,10,...,20},
-                  minor xtick={1,2,...,20},
-                  ytick={50,100,...,215},
-                  minor ytick={5, 10,...,200},
-                  xlabel={$t{}$, hours},
-                  ylabel={$A(t){}$, mg of drug},
-                  every axis x label/.style={at={(current axis.right of origin)},anchor=north east},
-                  width=1.5*\axisdefaultwidth,
-                  height=\axisdefaultheight,
-                  ]
-                \addplot[primarycurve,domain=0:20] [smooth] {200*x*e^(-0.4*x)};
-                \end{axis}
-              \end{tikzpicture}
-              </latex-image>
-            </image>
-          </sidebyside>
+          <image width="47%">
+            <description>
+              Interpreting function notation from a graph.
+            </description>
+            <latex-image>
+              \begin{tikzpicture}
+              \begin{axis}[
+                xmin=-1,
+                xmax=20,
+                ymin=-0.2,
+                ymax=215,
+                grid=both,
+                xtick={5,10,...,20},
+                minor xtick={1,2,...,20},
+                ytick={50,100,...,215},
+                minor ytick={5, 10,...,200},
+                xlabel={$t{}$, hours},
+                ylabel={$A(t){}$, mg of drug},
+                every axis x label/.style={at={(current axis.right of origin)},anchor=north east},
+                width=1.5*\axisdefaultwidth,
+                height=\axisdefaultheight,
+                ]
+              \addplot[primarycurve,domain=0:20] [smooth] {200*x*e^(-0.4*x)};
+              \end{axis}
+            \end{tikzpicture}
+            </latex-image>
+          </image>
         </statement>
       </exercise>
 
@@ -153,32 +151,30 @@
           <p>
             The graph in the figure shows two functions <m>f(x)</m>, linear, and <m>g(x)</m>, quadratic.
           </p>
-            <sidebyside widths="47%">
-              <image>
-                <description>
-                  Linear and Exponential Graphs (Combinations)
-                </description>
-                <latex-image>
-                  \begin{tikzpicture}
-                    \begin{axis}[
-                      xmin=-3,
-                      xmax=10,
-                      ymin=-8,
-                      ymax=8,
-                      grid=major,
-                      xtick={-2,-1,...,9},
-                      minor xtick={0},
-                      ytick={-7,-6,...,7},
-                      minor ytick={0},
-                      ]
-                      \addplot[primarycurve,-] coordinates {(-4, -5) (9,8)};
-                      \addplot[secondarycurve,-,domain=-3.5:10] {-1/4*(x-4)^2+6};
-                      \addplot[soldot,color=black] coordinates {(-2,-3) (0,-1) (2,1) (4,3) (6,5) (8,7) (0,2) (2,5) (4,6) (6,5) (8,2)};
-                    \end{axis}
-                  \end{tikzpicture}
-                </latex-image>
-              </image>
-            </sidebyside>
+          <image width="47%">
+            <description>
+              Linear and Exponential Graphs (Combinations)
+            </description>
+            <latex-image>
+              \begin{tikzpicture}
+                \begin{axis}[
+                  xmin=-3,
+                  xmax=10,
+                  ymin=-8,
+                  ymax=8,
+                  grid=major,
+                  xtick={-2,-1,...,9},
+                  minor xtick={0},
+                  ytick={-7,-6,...,7},
+                  minor ytick={0},
+                  ]
+                  \addplot[primarycurve,-] coordinates {(-4, -5) (9,8)};
+                  \addplot[secondarycurve,-,domain=-3.5:10] {-1/4*(x-4)^2+6};
+                  \addplot[soldot,color=black] coordinates {(-2,-3) (0,-1) (2,1) (4,3) (6,5) (8,7) (0,2) (2,5) (4,6) (6,5) (8,2)};
+                \end{axis}
+              \end{tikzpicture}
+            </latex-image>
+          </image>
           <p>
             <ol label="a">
               <li>
@@ -465,34 +461,32 @@
             the ball was kicked, and <m>f(x)</m> is its height above the ground
             (measured in feet).
           </p>
-          <sidebyside widths="47%">
-            <image>
-              <description>
-                Graph of height versus distance
-              </description>
-              <latex-image>
-                \begin{tikzpicture}
-                \begin{axis}[
-                  xmin=-0.1,
-                  xmax=2,
-                  ymin=-0.2,
-                  ymax=2,
-                  grid=none,
-                  xtick={0},
-                  minor xtick={0},
-                  ytick={0},
-                  minor ytick={0},
-                  xlabel={$x={}$ distance from the 30-yard line (in feet)},
-                  ylabel={$y={}$ height above the ground (in feet)},
-                  every axis x label/.style={at={(current axis.right of origin)},anchor=north east},
-                  width=1.5*\axisdefaultwidth,
-                  height=\axisdefaultheight,
-                  ]
-                \end{axis}
-              \end{tikzpicture}
-              </latex-image>
-            </image>
-          </sidebyside>
+          <image width="47%">
+            <description>
+              Graph of height versus distance
+            </description>
+            <latex-image>
+              \begin{tikzpicture}
+              \begin{axis}[
+                xmin=-0.1,
+                xmax=2,
+                ymin=-0.2,
+                ymax=2,
+                grid=none,
+                xtick={0},
+                minor xtick={0},
+                ytick={0},
+                minor ytick={0},
+                xlabel={$x={}$ distance from the 30-yard line (in feet)},
+                ylabel={$y={}$ height above the ground (in feet)},
+                every axis x label/.style={at={(current axis.right of origin)},anchor=north east},
+                width=1.5*\axisdefaultwidth,
+                height=\axisdefaultheight,
+                ]
+              \end{axis}
+            \end{tikzpicture}
+            </latex-image>
+          </image>
           <p>
             <ol label="a">
               <li>
@@ -702,36 +696,34 @@
           <p>
             The table shows the height of the water in a graduated cylinder as a function of the volume of water in the cylinder.
           </p>
-          <sidebyside>
-            <tabular top="medium" bottom="medium" left="medium" right="medium">
-              <col halign="center"/>
-              <col halign="center"/>
-              <row>
-                <cell>Volume <m>(cm^3)</m></cell>
-                <cell>Height <m>(cm)</m></cell>
-              </row>
-              <row>
-                <cell><m>50</m></cell>
-                <cell><m>0.6366</m></cell>
-              </row>
-              <row>
-                <cell><m>100</m></cell>
-                <cell><m>1.2732</m></cell>
-              </row>
-              <row>
-                <cell><m>150</m></cell>
-                <cell><m>1.9099</m></cell>
-              </row>
-              <row>
-                <cell><m>200</m></cell>
-                <cell><m>2.5465</m></cell>
-              </row>
-              <row>
-                <cell><m>250</m></cell>
-                <cell><m>3.1831</m></cell>
-              </row>
-            </tabular>
-          </sidebyside>
+          <tabular top="medium" bottom="medium" left="medium" right="medium">
+            <col halign="center"/>
+            <col halign="center"/>
+            <row>
+              <cell>Volume <m>(cm^3)</m></cell>
+              <cell>Height <m>(cm)</m></cell>
+            </row>
+            <row>
+              <cell><m>50</m></cell>
+              <cell><m>0.6366</m></cell>
+            </row>
+            <row>
+              <cell><m>100</m></cell>
+              <cell><m>1.2732</m></cell>
+            </row>
+            <row>
+              <cell><m>150</m></cell>
+              <cell><m>1.9099</m></cell>
+            </row>
+            <row>
+              <cell><m>200</m></cell>
+              <cell><m>2.5465</m></cell>
+            </row>
+            <row>
+              <cell><m>250</m></cell>
+              <cell><m>3.1831</m></cell>
+            </row>
+          </tabular>
           <p>
             <ol label="a">
               <li>
@@ -761,13 +753,11 @@
               </li>
             </ol>
           </p>
-          <sidebyside widths="15%">
-            <image source="images/graduated_cyl.png">
-              <description>
-                Picture of graduated cylinder
-              </description>
-            </image>
-          </sidebyside>
+          <image source="images/graduated_cyl.png" width="15%">
+            <description>
+              Picture of graduated cylinder
+            </description>
+          </image>
         </statement>
       </exercise>
 <exercise>
@@ -775,36 +765,34 @@
           <p>
             Find the area of the shaded triangular region.
           </p>
-          <sidebyside widths="47%">
-            <image>
-              <description>
-                area of triangle
-              </description>
-              <latex-image>
-                \begin{tikzpicture}
-                  \begin{axis}[
-                    xmin=-11,
-                    xmax=9,
-                    ymin=-7,
-                    ymax=9,
-                    grid=none,
-                    xtick={0},
-                    minor xtick={0},
-                    ytick={0},
-                    minor ytick={0},
-                    axis equal,
-                    ]
-                    \addplot[primarycurve] coordinates {(-7,-4) (-1,8)};
-                    \addplot[primarycurve] coordinates {(-7,6) (7,-1)};
-                    \addplot[soldot] coordinates {(-5,0)} node[above left] {$(-5,0)$};
-                    \addplot[soldot] coordinates {(-3,4)} node[left] {$(-3,4)$};
-                    \addplot[rightangle] coordinates {(-2, 3.5) (-2.5, 2.5) (-3.5,3)};
-                    \addplot[fill=secondcolor, opacity=0.5] coordinates {(0,0) (0,2.5) (5,0)};
-                  \end{axis}
-                \end{tikzpicture}
-              </latex-image>
-            </image>
-          </sidebyside>
+          <image width="47%">
+            <description>
+              area of triangle
+            </description>
+            <latex-image>
+              \begin{tikzpicture}
+                \begin{axis}[
+                  xmin=-11,
+                  xmax=9,
+                  ymin=-7,
+                  ymax=9,
+                  grid=none,
+                  xtick={0},
+                  minor xtick={0},
+                  ytick={0},
+                  minor ytick={0},
+                  axis equal,
+                  ]
+                  \addplot[primarycurve] coordinates {(-7,-4) (-1,8)};
+                  \addplot[primarycurve] coordinates {(-7,6) (7,-1)};
+                  \addplot[soldot] coordinates {(-5,0)} node[above left] {$(-5,0)$};
+                  \addplot[soldot] coordinates {(-3,4)} node[left] {$(-3,4)$};
+                  \addplot[rightangle] coordinates {(-2, 3.5) (-2.5, 2.5) (-3.5,3)};
+                  \addplot[fill=secondcolor, opacity=0.5] coordinates {(0,0) (0,2.5) (5,0)};
+                \end{axis}
+              \end{tikzpicture}
+            </latex-image>
+          </image>
         </statement>
       </exercise>
 
@@ -815,33 +803,31 @@
             The figure shows a rectangle whose sides are formed by four lines.
             Remember that sides of a rectangle are perpendicular.
           </p>
-          <sidebyside widths="47%">
-            <image>
-              <description>
-                Rectangle Area
-              </description>
-              <latex-image>
-                \begin{tikzpicture}
-                \begin{axis}[
-                  xmin=-26,
-                  xmax=10,
-                  ymin=-10,
-                  ymax=15,
-                  grid=none,
-                  xtick={0},
-                  minor xtick={0},
-                  ytick={0},
-                  minor ytick={0},
-                  axis equal,
-                  ]
-                  \addplot[color=firstcolor, fill=secondcolor, opacity=0.5] coordinates {(-16,4) (-10,12) (6,0) (0,-8) (-16,4)};
-                  \addplot[soldot] coordinates {(-16,4)} node[below left] {$(-16,4)$};
-                  \addplot[soldot] coordinates {(-10,12)} node[above] {$(-10,12)$};
-                \end{axis}
-              \end{tikzpicture}
-              </latex-image>
-            </image>
-          </sidebyside>
+          <image width="47%">
+            <description>
+              Rectangle Area
+            </description>
+            <latex-image>
+              \begin{tikzpicture}
+              \begin{axis}[
+                xmin=-26,
+                xmax=10,
+                ymin=-10,
+                ymax=15,
+                grid=none,
+                xtick={0},
+                minor xtick={0},
+                ytick={0},
+                minor ytick={0},
+                axis equal,
+                ]
+                \addplot[color=firstcolor, fill=secondcolor, opacity=0.5] coordinates {(-16,4) (-10,12) (6,0) (0,-8) (-16,4)};
+                \addplot[soldot] coordinates {(-16,4)} node[below left] {$(-16,4)$};
+                \addplot[soldot] coordinates {(-10,12)} node[above] {$(-10,12)$};
+              \end{axis}
+            \end{tikzpicture}
+            </latex-image>
+          </image>
           <p>
             Find the area of the rectangle.
           </p>
@@ -871,31 +857,29 @@
               </li>
             </ol>
           </p>
-            <sidebyside widths="47%">
-              <image>
-                <description>
-                  Parabola and point P
-                </description>
-                <latex-image>
-                  \begin{tikzpicture}
-                  \begin{axis}[
-                    xmin=-3,
-                    xmax=3,
-                    ymin=-2,
-                    ymax=5,
-                    grid=none,
-                    xtick={0},
-                    minor xtick={0},
-                    ytick={0},
-                    minor ytick={0},
-                    ]
-                    \addplot[primarycurve,domain=-2.8:1.8] {x*(x+1)};
-                    \addplot[soldot] coordinates {(1.5,3.75)} node[below right] {$P$};
-                  \end{axis}
-                \end{tikzpicture}
-                </latex-image>
-              </image>
-            </sidebyside>
+          <image width="47%">
+            <description>
+              Parabola and point P
+            </description>
+            <latex-image>
+              \begin{tikzpicture}
+              \begin{axis}[
+                xmin=-3,
+                xmax=3,
+                ymin=-2,
+                ymax=5,
+                grid=none,
+                xtick={0},
+                minor xtick={0},
+                ytick={0},
+                minor ytick={0},
+                ]
+                \addplot[primarycurve,domain=-2.8:1.8] {x*(x+1)};
+                \addplot[soldot] coordinates {(1.5,3.75)} node[below right] {$P$};
+              \end{axis}
+            \end{tikzpicture}
+            </latex-image>
+          </image>
         </statement>
       </exercise>
 
@@ -1273,44 +1257,42 @@
             degrees Fahrenheit outside, and the wind is blowing at <m>s</m>
             miles per hour.
           </p>
-          <sidebyside>
-            <tabular top="medium" bottom="medium" left="medium" right="medium">
-              <col halign="center"/>
-              <col halign="center"/>
-              <row>
-                <cell><em>s</em>, Wind Speed <m>(mph)</m></cell>
-                <cell><m>W(s)</m> (degrees Fahrenheit)</cell>
-              </row>
-              <row>
-                <cell><m>0</m></cell>
-                <cell><m>40</m></cell>
-              </row>
-              <row>
-                <cell><m>10</m></cell>
-                <cell><m>34</m></cell>
-              </row>
-              <row>
-                <cell><m>20</m></cell>
-                <cell><m>30</m></cell>
-              </row>
-              <row>
-                <cell><m>30</m></cell>
-                <cell><m>28</m></cell>
-              </row>
-              <row>
-                <cell><m>40</m></cell>
-                <cell><m>27</m></cell>
-              </row>
-              <row>
-                <cell><m>50</m></cell>
-                <cell><m>26</m></cell>
-              </row>
-              <row>
-                <cell><m>60</m></cell>
-                <cell><m>25</m></cell>
-              </row>
-            </tabular>
-          </sidebyside>
+          <tabular top="medium" bottom="medium" left="medium" right="medium">
+            <col halign="center"/>
+            <col halign="center"/>
+            <row>
+              <cell><em>s</em>, Wind Speed <m>(mph)</m></cell>
+              <cell><m>W(s)</m> (degrees Fahrenheit)</cell>
+            </row>
+            <row>
+              <cell><m>0</m></cell>
+              <cell><m>40</m></cell>
+            </row>
+            <row>
+              <cell><m>10</m></cell>
+              <cell><m>34</m></cell>
+            </row>
+            <row>
+              <cell><m>20</m></cell>
+              <cell><m>30</m></cell>
+            </row>
+            <row>
+              <cell><m>30</m></cell>
+              <cell><m>28</m></cell>
+            </row>
+            <row>
+              <cell><m>40</m></cell>
+              <cell><m>27</m></cell>
+            </row>
+            <row>
+              <cell><m>50</m></cell>
+              <cell><m>26</m></cell>
+            </row>
+            <row>
+              <cell><m>60</m></cell>
+              <cell><m>25</m></cell>
+            </row>
+          </tabular>
           <p>
             <ol label="a">
               <li>
@@ -1430,13 +1412,11 @@
           <p>
             Assign variable names to the two quantities, and write an equation involving a proportionality constant, k.
           </p>
-          <sidebyside widths="30%">
-            <image source="images/spring_hookes_law.png">
-              <description>
-                Picture of extended spring
-              </description>
-            </image>
-          </sidebyside>
+          <image source="images/spring_hookes_law.png" image="30%">
+            <description>
+              Picture of extended spring
+            </description>
+          </image>
         </statement>
       </exercise>
 

--- a/src/projects-function-notation.xml
+++ b/src/projects-function-notation.xml
@@ -1316,21 +1316,18 @@
               <li>
                 <p>
                   Which pair of statements is true?
-                  <p>
-                    <ul>
-                      <li>
-                        <p>
-                          <m>W(25)=60</m> and <m>W^{-1}(50)=26</m>
-                        </p>
-                      </li>
-                      <li>
-                        <p>
-                          <m>W(40)=27</m> and <m>W^{-1}(34)=10</m>
-                        </p>
-                      </li>
-                    </ul>
-                  </p>
-
+                  <ul>
+                    <li>
+                      <p>
+                        <m>W(25)=60</m> and <m>W^{-1}(50)=26</m>
+                      </p>
+                    </li>
+                    <li>
+                      <p>
+                        <m>W(40)=27</m> and <m>W^{-1}(34)=10</m>
+                      </p>
+                    </li>
+                  </ul>
                 </p>
               </li>
               <li>

--- a/src/projects-function-notation.xml
+++ b/src/projects-function-notation.xml
@@ -11,16 +11,14 @@
 -->
 <section xml:id="projects-function-notation" xmlns:xi="http://www.w3.org/2001/XInclude">
   <title>Projects: Functions and Notation</title>
-  <introduction>
-    <p>
-      Show all your work when algebra is necessary or when making calculations.
-      If reading a graph or table, briefly explain how you used the graph or the table
-      to arrive at your answer.
-    </p>
-  </introduction>
+  <p>
+    Show all your work when algebra is necessary or when making calculations.
+    If reading a graph or table, briefly explain how you used the graph or the table
+    to arrive at your answer.
+  </p>
 
   <exercises>
-    <subsection>
+    <subexercises>
       <title>Evaluate, apply and interpret function notation, including the notation for inverse functions and composition of Functions</title>
 
         <exercise>
@@ -659,9 +657,9 @@
       </exercise>
 
       
-    </subsection>
+    </subexercises>
 
-    <subsection>
+    <subexercises>
       <title>Maintain and strengthen prerequisites, especially: percent, linear and quadratic functions, solving equations.</title>
       
       <exercise>
@@ -907,9 +905,9 @@
       </exercise>
 
       
-    </subsection>
+    </subexercises>
 
-    <subsection>
+    <subexercises>
       <title>Determine the domain and range of functions</title>
       <exercise>
         <statement>
@@ -939,9 +937,9 @@
           </p>
         </statement>
       </exercise>
-    </subsection>
+    </subexercises>
 
-    <subsection>
+    <subexercises>
       <title>Exponential Functions and Constant Percent Change</title>
 
       <exercise>
@@ -1021,9 +1019,9 @@
         </statement>
       </exercise>
 
-    </subsection>
+    </subexercises>
 
-    <subsection>
+    <subexercises>
       <title>Solve equations algebraically using properties of exponents and logarithms</title>
 <!--       <exercise>
         <statement>
@@ -1072,17 +1070,17 @@
         </statement>
       </exercise> -->
 
-    </subsection>
+    </subexercises>
 
-    <subsection>
+    <subexercises>
       <title>Horizontal and Vertical Translations</title>
       
 
-    </subsection>
+    </subexercises>
 
 
 
-    <subsection>
+    <subexercises>
       <title>Composition and Inverse</title>
 
       <exercise>
@@ -1350,9 +1348,9 @@
         </statement>
       </exercise>
 
-    </subsection>
+    </subexercises>
 
-    <subsection>
+    <subexercises>
       <title>
         Use the characteristics of basic functions (linear, constant, polynomial, exponential, logarithmic, power, piece-wise), especially slope, intercepts, rate of change, percent change and average change, to answer questions in application situations, to write equations and to create graphs by hand and on the calculator.
       </title>
@@ -1506,8 +1504,8 @@
           </p>
         </statement>
       </exercise>
-    </subsection>
-    <subsection>
+    </subexercises>
+    <subexercises>
       <title>Recognize an exponential relationship given numerically or verbally, determine the growth/decay rate and use this information to write an equation to model the relationship</title>
 
       <exercise>
@@ -1594,7 +1592,7 @@
         </statement>
       </exercise>
 
-    </subsection>
+    </subexercises>
 
   </exercises>
 </section>

--- a/src/projects-function-notation.xml
+++ b/src/projects-function-notation.xml
@@ -189,26 +189,25 @@
               <li>
                 <p>
                   Let <m>S(x)=f(x)+g(x)</m>, <m>P(x)=f(x)*g(x)</m> and <m>Q(x)= \frac{f(x)}{g(x)}</m>
-                <p/>
-                  <p>
-                    <ol label="i">
-                      <li>
-                        <p>
-                          Evaluate <m>S(-2)</m>
-                        </p>
-                      </li>
-                      <li>
-                        <p>
-                          Evaluate <m>P(8)</m>
-                        </p>
-                      </li>
-                      <li>
-                        <p>
-                          Solve <m>Q(x)=0</m>
-                        </p>
-                      </li>
-                    </ol>
-                  </p>
+                </p>
+                <p>
+                  <ol label="i">
+                    <li>
+                      <p>
+                        Evaluate <m>S(-2)</m>
+                      </p>
+                    </li>
+                    <li>
+                      <p>
+                        Evaluate <m>P(8)</m>
+                      </p>
+                    </li>
+                    <li>
+                      <p>
+                        Solve <m>Q(x)=0</m>
+                      </p>
+                    </li>
+                  </ol>
                 </p>
               </li>
             </ol>

--- a/src/projects-function-notation.xml
+++ b/src/projects-function-notation.xml
@@ -1067,11 +1067,11 @@
 
     </subexercises>
 
-    <subexercises>
+    <!-- <subexercises>
       <title>Horizontal and Vertical Translations</title>
       
 
-    </subexercises>
+    </subexercises> -->
 
 
 

--- a/src/projects-function-notation.xml
+++ b/src/projects-function-notation.xml
@@ -1445,55 +1445,53 @@
           <p>
             Each line in the figures has a slope of <m>\frac{1}{2}</m>. For each graph, determine the value of <m>a</m> within the given coordinates.
           </p>
-          <p>
-            <sidebyside widths="47% 47%">
-              <image>
-                <description>
-                  Linear Graphs with slope <m>\frac{1}{2}</m>
-                </description>
-                <latex-image>
-                  \begin{tikzpicture}
-                    \begin{axis}[
-                      xmin=-2,
-                      xmax=12,
-                      ymin=-2,
-                      ymax=12,
-                      grid=none,
-                      xtick={0},
-                      minor xtick={0},
-                      ytick={0},
-                      minor ytick={0},
-                      ]
-                      \addplot[primarycurve,-] coordinates {(-2, 4) (12,11)};
-                      \addplot[soldot] coordinates {(4,7)} node[below right] {$(4,7)$};
-                      \addplot[soldot] coordinates {(9,9.5)} node[below right] {$(9,a)$};
-                    \end{axis}
-                  \end{tikzpicture}
-                </latex-image>
-              </image>
-              <image>
-                <latex-image>
-                  \begin{tikzpicture}
-                    \begin{axis}[
-                      xmin=-2,
-                      xmax=12,
-                      ymin=-2,
-                      ymax=12,
-                      grid=none,
-                      xtick={0},
-                      minor xtick={0},
-                      ytick={0},
-                      minor ytick={0},
-                      ]
-                      \addplot[primarycurve,-] coordinates {(-2, 3) (12,10)};
-                      \addplot[soldot] coordinates {(2,5)} node[below right] {$(2,5)$};
-                      \addplot[soldot] coordinates {(8,8)} node[below right] {$(a,8)$};
-                    \end{axis}
-                  \end{tikzpicture}
-                </latex-image>
-              </image>
-            </sidebyside>
-          </p>
+          <sidebyside widths="47% 47%">
+            <image>
+              <description>
+                Linear Graphs with slope <m>\frac{1}{2}</m>
+              </description>
+              <latex-image>
+                \begin{tikzpicture}
+                  \begin{axis}[
+                    xmin=-2,
+                    xmax=12,
+                    ymin=-2,
+                    ymax=12,
+                    grid=none,
+                    xtick={0},
+                    minor xtick={0},
+                    ytick={0},
+                    minor ytick={0},
+                    ]
+                    \addplot[primarycurve,-] coordinates {(-2, 4) (12,11)};
+                    \addplot[soldot] coordinates {(4,7)} node[below right] {$(4,7)$};
+                    \addplot[soldot] coordinates {(9,9.5)} node[below right] {$(9,a)$};
+                  \end{axis}
+                \end{tikzpicture}
+              </latex-image>
+            </image>
+            <image>
+              <latex-image>
+                \begin{tikzpicture}
+                  \begin{axis}[
+                    xmin=-2,
+                    xmax=12,
+                    ymin=-2,
+                    ymax=12,
+                    grid=none,
+                    xtick={0},
+                    minor xtick={0},
+                    ytick={0},
+                    minor ytick={0},
+                    ]
+                    \addplot[primarycurve,-] coordinates {(-2, 3) (12,10)};
+                    \addplot[soldot] coordinates {(2,5)} node[below right] {$(2,5)$};
+                    \addplot[soldot] coordinates {(8,8)} node[below right] {$(a,8)$};
+                  \end{axis}
+                \end{tikzpicture}
+              </latex-image>
+            </image>
+          </sidebyside>
         </statement>
       </exercise>
     </subexercises>

--- a/src/projects-function-notation.xml
+++ b/src/projects-function-notation.xml
@@ -129,7 +129,7 @@
                   Match each expression to the correct phrase:
                 </p>
                 <statement>
-                  <table>
+                  <figure>
                     <tabular top="medium" bottom="medium" left="medium" right="medium">
                       <col halign="center"/>
                       <col halign="center"/>
@@ -146,7 +146,7 @@
                         <cell>The surface area of a can whose radius is <m>3</m> times as large as <m>r</m></cell>
                       </row>
                     </tabular>
-                  </table>
+                  </figure>
                 </statement>
               </li>
             </ol>

--- a/src/sandbox.xml
+++ b/src/sandbox.xml
@@ -14,7 +14,6 @@
   <exercises>
     <exercise>
     <webwork>
-        <setup>
 
         <pg-code>
           Context()->variables->are(a=>'Real', b=>'Real', c=>'Real', d=>'Real');
@@ -23,7 +22,6 @@
           list_random(@letters);  
           $var=$letters[random($total)];
         </pg-code>
-        </setup>
         <statement>
           <p>
             Let <m>w</m> be a function and <m>w^{-1}</m> be its inverse.

--- a/src/sandbox.xml
+++ b/src/sandbox.xml
@@ -19,7 +19,7 @@
           Context()->variables->are(a=>'Real', b=>'Real', c=>'Real', d=>'Real');
           $num=random(3,20,1);
           @letters = ('a'..'d');
-          list_random(@letters);  
+          list_random(@letters);
           $var=$letters[random($total)];
         </pg-code>
         <statement>


### PR DESCRIPTION
These commits clear up the schema violations. There are only a few violations left after this. Most of them are supposed to be OK (using `@width` on an image) and I have a PR coming soon to mathbook that will address that. Then the only schema violations left will be a few places where an image is inside a list item. Technically that is a violation, but it should work in output.

Next step for me is to look more closely and see where to make substantive improvements. I have a few things in mind: WeBWorK coding structures and when/where subdivisions (`subsection`, `subexercises`, etc) are being used. But for now, clearing schema violations seems like a good milestone to open a PR.