### PR TITLE
GGB move and cleanup of abbr|init|acro

### DIFF
--- a/src/activity-average-rate-of-change.xml
+++ b/src/activity-average-rate-of-change.xml
@@ -58,10 +58,11 @@
             <pg-code>
                 $train = RadioButtons(["Blue Train (dotted line)","Red Train (dashed line)","Green Train (solid line)"],0);
                 $slope = RadioButtons(["mope","dope","slope","scope"],2);
+                $ggb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/mYBwwJSp/width/413/height/331/border/888888" width="413px" height="331px" style="border:0px;" width="431px" height="313px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
             </pg-code>
           <statement>
             <p>
-              [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/mYBwwJSp/width/413/height/331/border/888888" width="413px" height="331px" style="border:0px;" width="431px" height="313px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+              <var name="$ggb" data="pgml"/>
             </p>
 
             <p>
@@ -195,10 +196,11 @@
                 Context()->flags->set(reduceConstantFunctions=>0);
                 Context()->flags->set(formatStudentAnswer=>"parsed");
                 $difference=Formula("f(5)-f(2)");
+                $ggb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/ZVx2N298/width/431/height/250/border/888888/smb/false/stb/false/stbh/false/ai/false/asb/false/sri/false/rc/false/ld/false/sdz/false/ctl/false" width="431px" height="250px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
             </pg-code>
           <statement>
             <p>
-              [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/ZVx2N298/width/431/height/250/border/888888/smb/false/stb/false/stbh/false/ai/false/asb/false/sri/false/rc/false/ld/false/sdz/false/ctl/false" width="431px" height="250px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+              <var name="$ggb" data="pgml"/>
             </p>
 
             <p>
@@ -315,10 +317,11 @@
             <pg-code>
                 $chngDist = Real(19.5);
                 $meaning = PopUp(["?", "Change in hours since 8 AM.", "Delta t", "Delta times t", "There is no meaning to this expression"], 1);
+                $ggb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/ZVx2N298/width/431/height/250/border/888888/smb/false/stb/false/stbh/false/ai/false/asb/false/sri/false/rc/false/ld/false/sdz/false/ctl/false" width="431px" height="250px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
             </pg-code>
           <statement>
             <p>
-              [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/ZVx2N298/width/431/height/250/border/888888/smb/false/stb/false/stbh/false/ai/false/asb/false/sri/false/rc/false/ld/false/sdz/false/ctl/false" width="431px" height="250px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+              <var name="$ggb" data="pgml"/>
             </p>
 
             <p>
@@ -552,11 +555,14 @@
                 Context()->variables->are(x=>'Real',y=>'Real');
                 $lineA = ImplicitPlane("y=-x+7");
                 $lineB = ImplicitPlane("y=2x+1");
+                $ggb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/vB6mAHUg/width/413/height/331/border/888888" width="413px" height="331px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
+                $ggb2 = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/vdbw2XUs/width/413/height/331/border/888888" width="413px" height="331px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
+                $ggb3 = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/GxRSTPsw/width/413/height/331/border/888888" width="413px" height="331px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
             </pg-code>
           <stage>
           <statement>
             <p>
-              [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/vB6mAHUg/width/413/height/331/border/888888" width="413px" height="331px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+              <var name="$ggb" data="pgml"/>
             </p>
 
             <p>
@@ -621,7 +627,7 @@
           <stage>
           <statement>
             <p>
-              [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/vdbw2XUs/width/413/height/331/border/888888" width="413px" height="331px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+              <var name="$ggb2" data="pgml"/>
             </p>
 
             <p>
@@ -705,7 +711,7 @@
           <stage>
           <statement>
             <p>
-              [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/GxRSTPsw/width/413/height/331/border/888888" width="413px" height="331px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+              <var name="$ggb3" data="pgml"/>
             </p>
 
             <p>
@@ -771,10 +777,11 @@
               Context("Inequalities");
               Context()->variables->are(m => "Real");
               $intMarch = Compute("3&lt;=m&lt;=12");
+              $ggb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/PPsZ6cgY/width/431/height/245/border/888888/smb/false/stb/false/stbh/false/ai/false/asb/false/sri/false/rc/false/ld/false/sdz/false/ctl/false" width="431px" height="245px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
             </pg-code>
           <statement>
             <p>
-              [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/PPsZ6cgY/width/431/height/245/border/888888/smb/false/stb/false/stbh/false/ai/false/asb/false/sri/false/rc/false/ld/false/sdz/false/ctl/false" width="431px" height="245px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+              <var name="$ggb" data="pgml"/>
             </p>
 
             <p>
@@ -1049,10 +1056,11 @@
                 $meaning = PopUp(["?", "distance of the train from downtown", "time the train has traveled", "average speed of the train", "triangle D divided by triangle t"], 3);
                 $lastUnit = PopUp(["?", "miles", "hours per mile", "hours", "miles per hour"], 4);
                 $interval = PopUp(["?", "2 PM and 5 PM", "10 AM and 1 PM", "2 and 5", "2 mph and 5 mph"], 2);
+                $ggb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/ZVx2N298/width/413/height/250/border/888888" width="413px" height="250px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
             </pg-code>
           <statement>
             <p>
-              [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/ZVx2N298/width/413/height/250/border/888888" width="413px" height="250px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+              <var name="$ggb" data="pgml"/>
             </p>
 
             <p>

--- a/src/activity-average-rate-of-change.xml
+++ b/src/activity-average-rate-of-change.xml
@@ -177,7 +177,7 @@
       <introduction>
         <p>
           The interactive graph below is that of a function <m>D = f(t)</m> where <em>D</em>
-          is the number of miles a train is from downtown at <m>t</m> hours after 8 am.
+          is the number of miles a train is from downtown at <m>t</m> hours after 8 <am/>.
         </p>
       </introduction>
 
@@ -210,7 +210,7 @@
               <ol label="a">
                 <li>
                   <p>
-                    Use the graph to find the change in distance between the <m>9{:}00</m> and <m>11{:}00</m> <init>A.M.</init>.
+                    Use the graph to find the change in distance between the <m>9{:}00</m> and <m>11{:}00</m> <am/>.
                   </p>
 
                   <p>
@@ -220,7 +220,7 @@
 
                 <li>
                   <p>
-                    What is the change in time between the <m>9{:}00</m> and <m>11{:}00</m> <init>A.M.</init>?
+                    What is the change in time between the <m>9{:}00</m> and <m>11{:}00</m> <am/>?
                   </p>
 
                   <p>
@@ -232,7 +232,7 @@
                   <p>
                     What is the average speed
                     (rate of change)
-                    between <m>9{:}00</m> and <m>11{:}00</m> <init>A.M.</init>?
+                    between <m>9{:}00</m> and <m>11{:}00</m> <am/>?
                   </p>
 
                   <p>
@@ -246,7 +246,7 @@
                     (as in part a)
                     to write an expression that represents the
                     <em>change in distance</em>
-                    between the <m>10{:}00</m> <init>A.M.</init> and <m>1{:}00</m> <init>P.M.</init>.
+                    between the <m>10{:}00</m> <am/> and <m>1{:}00</m> <pm/>.
                   </p>
 
                   <p>
@@ -314,7 +314,7 @@
 
             <pg-code>
                 $chngDist = Real(19.5);
-                $meaning = PopUp(["?", "Change in hours since 8 a.m.", "Delta t", "Delta times t", "There is no meaning to this expression"], 1);
+                $meaning = PopUp(["?", "Change in hours since 8 AM.", "Delta t", "Delta times t", "There is no meaning to this expression"], 1);
             </pg-code>
           <statement>
             <p>
@@ -1030,7 +1030,7 @@
     </p>
 
     <p>
-      Let's finish this activity by going back to the train example where the distance (miles) of the train from downtown is a function of the time (hours) after 8 a.m.
+      Let's finish this activity by going back to the train example where the distance (miles) of the train from downtown is a function of the time (hours) after 8 <am/>.
       In other words <m>D = f(t)</m>.
     </p>
 
@@ -1048,7 +1048,7 @@
                 $speed= Real(45);
                 $meaning = PopUp(["?", "distance of the train from downtown", "time the train has traveled", "average speed of the train", "triangle D divided by triangle t"], 3);
                 $lastUnit = PopUp(["?", "miles", "hours per mile", "hours", "miles per hour"], 4);
-                $interval = PopUp(["?", "2 p.m. and 5 p.m.", "10 a.m. and 1 p.m.", "2 and 5", "2 mph and 5 mph"], 2);
+                $interval = PopUp(["?", "2 PM and 5 PM", "10 AM and 1 PM", "2 and 5", "2 mph and 5 mph"], 2);
             </pg-code>
           <statement>
             <p>

--- a/src/activity-combinations-of-functions.xml
+++ b/src/activity-combinations-of-functions.xml
@@ -452,6 +452,8 @@
           $didItGraph=PopUp(
           ["?","yes","no"],"yes"
           );
+          $ggb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/MyMCZCZ6/width/433/height/311/border/888888/sri/true/sdz/false/" width="433px" height="311px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
+          $ggb2 = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/xE8wUtMM/width/433/height/493/border/888888/sri/true/sdz/false/" width="433px" height="493px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
         </pg-code>
         <stage>
         <statement>
@@ -464,7 +466,7 @@
           </p>
 
           <p>
-            [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/MyMCZCZ6/width/433/height/311/border/888888/sri/true/sdz/false/" width="433px" height="311px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+            <var name="$ggb" data="pgml"/>
           </p>
 
           <p>
@@ -625,7 +627,7 @@
           </p>
 
           <p>
-            [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/xE8wUtMM/width/433/height/493/border/888888/sri/true/sdz/false/" width="433px" height="493px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+            <var name="$ggb2" data="pgml"/>
           </p>
 
           <p>
@@ -648,7 +650,7 @@
           $f=Compute("-1+0.5*x");
           $g=Compute("2-0.25*x");
           $P=Compute("$f*$g");
-
+          $ggb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/MyMCZCZ6/width/433/height/311/border/888888/sri/true/sdz/false/" width="433px" height="311px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
         </pg-code>
         <statement>
           <p>
@@ -656,7 +658,7 @@
           </p>
 
           <p>
-            [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/MyMCZCZ6/width/433/height/311/border/888888/sri/true/sdz/false/" width="433px" height="311px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+            <var name="$ggb" data="pgml"/>
           </p>
 
           <p>
@@ -737,6 +739,7 @@
           $hZero=Real(4.4);
           $hPositive=OneOf(0,2.1);
           $hNegative=OneOf(-3,7);
+          $ggb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/uSYHMfWJ/width/422/height/427/border/888888/sri/true/sdz/false/" width="422px" height="427px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
         </pg-code>
         <statement>
           <p>
@@ -752,7 +755,7 @@
           </p>
 
           <p>
-            [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/uSYHMfWJ/width/422/height/427/border/888888/sri/true/sdz/false/" width="422px" height="427px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+            <var name="$ggb" data="pgml"/>
           </p>
 
           <p>

--- a/src/activity-composition.xml
+++ b/src/activity-composition.xml
@@ -34,6 +34,7 @@
             Context()->variables->are(t=>'Real', r=>'Real');
             $radiusNum=Real(38);
             $areaNum=Compute("pi*38**2");
+            $ggb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/BuRF78AY/width/425/height/373/border/888888/sdz/false/" width="425px" height="373px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
           </pg-code>
         <statement>
           <p>
@@ -49,7 +50,7 @@
           </p>
 
           <p>
-            [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/BuRF78AY/width/425/height/373/border/888888/sdz/false/" width="425px" height="373px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+            <var name="$ggb" data="pgml"/>
           </p>
 
           <p>
@@ -371,6 +372,7 @@
             $input=random(1,10,1);
             $g=Compute("3*$input");
             $fofg=Compute("$g**2-$g");
+            $ggb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/vZUDWFjJ/width/425/height/420/border/888888/sri/true/sdz/false/" width="425px" height="420px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
           </pg-code>
         <statement>
           <p>
@@ -386,7 +388,7 @@
           </p>
 
           <p>
-            [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/vZUDWFjJ/width/425/height/420/border/888888/sri/true/sdz/false/" width="425px" height="420px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+            <var name="$ggb" data="pgml"/>
           </p>
 
           <p>
@@ -621,10 +623,11 @@
             $GofF=2-abs($F[0]);
             $FofF=abs($F[1]-1)-4;
             $GofG=2-abs($G[1]);
+            $ggb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/WJymUNhx/width/432/height/373/border/888888/sdz/false/" width="432px" height="373px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
           </pg-code>
         <statement>
           <p>
-            [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/WJymUNhx/width/432/height/373/border/888888/sdz/false/" width="432px" height="373px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+            <var name="$ggb" data="pgml"/>
           </p>
 
           <p>

--- a/src/activity-describing-functions.xml
+++ b/src/activity-describing-functions.xml
@@ -596,7 +596,7 @@
                     On what intervals is the function increasing?
                     For increasing or decreasing intervals of continuous functions,
                     we always include the ends of the intervals
-                    (unless the interval is unbounded <init>i.e.</init> is at infinity).
+                    (unless the interval is unbounded i.e.<nbsp/>is at infinity).
                   </p>
 
                   <p>
@@ -619,7 +619,7 @@
                     On what intervals is the function concave up?
                     For concave up or down intervals of continuous functions,
                     we always include the ends of the intervals
-                    (unless the interval is unbounded <init>i.e.</init> is at infinity).
+                    (unless the interval is unbounded i.e.<nbsp/>is at infinity).
                   </p>
 
                   <p>

--- a/src/activity-describing-functions.xml
+++ b/src/activity-describing-functions.xml
@@ -70,23 +70,26 @@
                         $answer1 = Compute("-2&lt;x&lt;=1");
                         $answer2 = Compute("x&lt;-2orx&gt;=1");
                         $answer3 = Compute("x&lt;=-2orx&gt;=1");
+                        $ggb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/XT6ddYvA/width/431/height/100/border/888888" width="431px" height="100px" style="border:0px;" width="431px" height="313px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
+                        $ggb2 = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/xBQKE3fm/width/431/height/100/border/888888/sri/true" width="431px" height="100px" style="border:0px;" width="431px" height="313px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
+                        $ggb3 = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/dDq6e5G4/width/431/height/100/border/888888/sri/true" width="431px" height="100px" style="border:0px;" width="431px" height="313px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
                     </pg-code>
 
                 <statement>
                     <p>Remember that open circles mean <q>include</q> while closed circles mean <q>not include</q>.</p>
                     <p><ol label="a">
                         <li>
-                            <p>[@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/XT6ddYvA/width/431/height/100/border/888888" width="431px" height="100px" style="border:0px;" width="431px" height="313px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*</p>
+                            <p><var name="$ggb" data="pgml"/></p>
                             <p>Represent the shaded region above with inequalities using the variable <m>x</m>.</p>
                             <p><var name="$answer1" width="30" /></p>
                         </li>
                         <li>
-                            <p>[@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/xBQKE3fm/width/431/height/100/border/888888/sri/true" width="431px" height="100px" style="border:0px;" width="431px" height="313px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*</p>
+                            <p><var name="$ggb2" data="pgml"/></p>
                             <p>Represent the shaded region above with inequalities using the variable <m>x</m>.</p>
                             <p><var name="$answer2" width="30" /></p>
                         </li>
                         <li>
-                            <p>[@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/dDq6e5G4/width/431/height/100/border/888888/sri/true" width="431px" height="100px" style="border:0px;" width="431px" height="313px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*</p>
+                            <p><var name="$ggb3" data="pgml"/></p>
                             <p>Represent the shaded region above with inequalities using the variable <m>x</m>.</p>
                             <p><var name="$answer3" width="30" /></p>
                         </li>
@@ -309,10 +312,11 @@
             <pg-code>
                 $positive = RadioButtons(["below the horizontal axis.","above the horizontal axis."],1);
                 $negative = RadioButtons(["below the horizontal axis.","above the horizontal axis."],0);
+                $ggb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/sHzc76gr/width/431/height/313/border/888888/sri/true" width="431px" height="313px" style="border:0px;" width="431px" height="313px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
             </pg-code>
           <statement>
             <p>
-              [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/sHzc76gr/width/431/height/313/border/888888/sri/true" width="431px" height="313px" style="border:0px;" width="431px" height="313px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+              <var name="$ggb" data="pgml"/>
             </p>
 
             <p>
@@ -384,10 +388,11 @@
               $inc2 = Compute("4&lt;=x&lt;=6");
               $dec1 = Compute("2&lt;=x&lt;=4");
               $dec2 = Compute("6&lt;=x&lt;=8");
+              $ggb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/pbwn6UAF/width/431/height/230/border/888888/smb/false/stb/false/stbh/false/ai/false/asb/false/sri/false/rc/false/ld/false/sdz/false/ctl/false" width="431px" height="230px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
             </pg-code>
           <statement>
             <p>
-              [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/pbwn6UAF/width/431/height/230/border/888888/smb/false/stb/false/stbh/false/ai/false/asb/false/sri/false/rc/false/ld/false/sdz/false/ctl/false" width="431px" height="230px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+              <var name="$ggb" data="pgml"/>
             </p>
 
             <p>
@@ -473,10 +478,11 @@
             <pg-code>
                 $cUp = RadioButtons(["concave up.","concave down."],0);
                 $cDwn = RadioButtons(["concave up.","concave down."],1);
+                $ggb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/NrncRJR3/width/431/height/300/border/888888/sri/true" width="431px" height="300px" style="border:0px;" width="431px" height="313px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
             </pg-code>
           <statement>
             <p>
-              [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/NrncRJR3/width/431/height/300/border/888888/sri/true" width="431px" height="300px" style="border:0px;" width="431px" height="313px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+              <var name="$ggb" data="pgml"/>
             </p>
 
             <p>
@@ -531,10 +537,11 @@
                 $cUp = Compute("0&lt;=t&lt;=9");
                 $cUp2 = Compute("21&lt;=t&lt;=24");
                 $cDwn = Compute("9&lt;=t&lt;=21");
+                $ggb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/tmanmNPG/width/431/height/300/border/888888/sri/true" width="431px" height="300px" style="border:0px;" width="431px" height="313px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
             </pg-code>
           <statement>
             <p>
-              [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/tmanmNPG/width/431/height/300/border/888888/sri/true" width="431px" height="300px" style="border:0px;" width="431px" height="313px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+              <var name="$ggb" data="pgml"/>
             </p>
 
             <p>

--- a/src/activity-domain-range.xml
+++ b/src/activity-domain-range.xml
@@ -279,11 +279,12 @@
             $yes2 = PopUp(["?","yes","no"],"yes");
             $no = PopUp(["?","yes","no"],"no");
             $domain = PopUp(["?","only positive numbers","all real numbers","only negative numbers","only numbers ending in C"],"all real numbers");
+            $ggb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/FRZgk5eU/width/413/height/350/border/888888" width="413px" height="350px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
           </pg-code>
           <stage>
           <statement>
             <p>
-              [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/FRZgk5eU/width/413/height/350/border/888888" width="413px" height="350px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+              <var name="$ggb" data="pgml"/>
             </p>
 
             <p>
@@ -347,10 +348,11 @@
             $pos2 = PopUp(["?","positive","negative"],"positive");
             $no = PopUp(["?","yes","no"],"no");
             $range = PopUp(["?","only positive numbers","all real numbers","only negative numbers","all real numbers greater than or equal to zero"],"all real numbers greater than or equal to zero");
+            $ggb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/FRZgk5eU/width/413/height/350/border/888888" width="413px" height="350px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
           </pg-code>
           <statement>
             <p>
-              [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/FRZgk5eU/width/413/height/350/border/888888" width="413px" height="350px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+              <var name="$ggb" data="pgml"/>
             </p>
 
             <p>
@@ -475,9 +477,12 @@
 
     <exercise>
       <webwork>
+          <pg-code>
+            $ggb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/KeUqTgkB/width/413/height/410/border/888888" width="413px" height="410px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
+          </pg-code>
           <statement>
             <p>
-              [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/KeUqTgkB/width/413/height/410/border/888888" width="413px" height="410px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+              <var name="$ggb" data="pgml"/>
             </p>
 
             <p>
@@ -893,11 +898,14 @@
             $dom2 = Compute("2&lt;x&lt;=5");
             $rng1 = Compute("-3&lt;=y&lt;=-0.5");
             $rng2 = Compute("2&lt;y&lt;=8");
+            $ggb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/AsPd6ZyS/width/413/height/370/border/888888" width="413px" height="370px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
+            $ggb2 = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/sVku4sA4/width/413/height/370/border/888888" width="413px" height="370px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
+            $ggb3 = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/WhcSmWsn/width/413/height/370/border/888888" width="413px" height="370px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
           </pg-code>
           <stage>
           <statement>
             <p>
-              [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/AsPd6ZyS/width/413/height/370/border/888888" width="413px" height="370px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+              <var name="$ggb" data="pgml"/>
             </p>
 
             <p>
@@ -934,7 +942,7 @@
           <stage>
           <statement>
             <p>
-              [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/sVku4sA4/width/413/height/370/border/888888" width="413px" height="370px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+              <var name="$ggb2" data="pgml"/>
             </p>
 
             <p>
@@ -969,7 +977,7 @@
           <stage>
           <statement>
             <p>
-              [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/WhcSmWsn/width/413/height/370/border/888888" width="413px" height="370px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+              <var name="$ggb3" data="pgml"/>
             </p>
 
             <p>
@@ -1001,11 +1009,14 @@
               $rng1 = Compute("0.78&lt;=y&lt;4.62");
               $rng2 = Compute("0.78&lt;=y&lt;4.62");
               $rng3 = Compute("1.95&lt;=y&lt;4.62");
+              $ggb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/TdQ8ajW3/width/413/height/270/border/888888" width="413px" height="270px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
+              $ggb2 = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/TdQ8ajW3/width/413/height/270/border/888888" width="413px" height="270px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
+              $ggb3 = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/TdQ8ajW3/width/413/height/270/border/888888" width="413px" height="270px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
             </pg-code>
           <stage>
           <statement>
             <p>
-              [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/TdQ8ajW3/width/413/height/270/border/888888" width="413px" height="270px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+              <var name="$ggb" data="pgml"/>
             </p>
 
             <p>
@@ -1032,7 +1043,7 @@
           <stage>
           <statement>
             <p>
-              [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/TdQ8ajW3/width/413/height/270/border/888888" width="413px" height="270px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+              <var name="$ggb2" data="pgml"/>
             </p>
 
             <p>
@@ -1060,7 +1071,7 @@
           <stage>
           <statement>
             <p>
-              [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/TdQ8ajW3/width/413/height/270/border/888888" width="413px" height="270px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+              <var name="$ggb3" data="pgml"/>
             </p>
 
             <p>

--- a/src/activity-domain-range.xml
+++ b/src/activity-domain-range.xml
@@ -835,28 +835,28 @@
                 <li>
                   <p>
                     In order for <m>x-4</m> to be such that
-                    <m>x - 4 \geqslant 0</m> (<abbr>i.e.</abbr> non-negative) then <m>x \geqslant 4</m>
+                    <m>x - 4 \geqslant 0</m> (i.e.<nbsp/>non-negative) then <m>x \geqslant 4</m>
                   </p>
                 </li>
 
                 <li>
                   <p>
                     In order for <m>4-x</m> to be such that
-                    <m>4-x \geqslant 0</m> (<abbr>i.e.</abbr> non-negative) then <m>x \leqslant 4</m>
+                    <m>4-x \geqslant 0</m> (i.e.<nbsp/>non-negative) then <m>x \leqslant 4</m>
                   </p>
                 </li>
 
                 <li>
                   <p>
                     In order for <m>x-7</m> to be such that
-                    <m>x-7 \neq 0</m> (<abbr>i.e.</abbr> non-zero) then <m>x\neq 7</m>
+                    <m>x-7 \neq 0</m> (i.e.<nbsp/>non-zero) then <m>x\neq 7</m>
                   </p>
                 </li>
 
                 <li>
                   <p>
                     In order for <m>x^2-9</m> to be such that
-                    <m>x^2-9 \neq 0</m> (<abbr>i.e.</abbr> non-zero) then <m>x\neq \pm 3</m>
+                    <m>x^2-9 \neq 0</m> (i.e.<nbsp/>non-zero) then <m>x\neq \pm 3</m>
                   </p>
                 </li>
               </ol>

--- a/src/activity-end-behavior-and-asymptotes.xml
+++ b/src/activity-end-behavior-and-asymptotes.xml
@@ -90,10 +90,11 @@
             $endBehavior=PopUp(["?","end behavior"],"end behavior");
             $power=PopUp(["?","x^2","x^3"],"x^3");
             $term=Compute("x^3");
+            $ggb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/Abx2UAXB/width/425/height/373/border/888888" width="425px" height="373px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
           </pg-code>
         <statement>
           <p>The graph below shows: <me>f(x) = x(x+3)(x-4)</me></p>
-          <p>[@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/Abx2UAXB/width/425/height/373/border/888888" width="425px" height="373px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*</p>
+          <p><var name="$ggb" data="pgml"/></p>
           <p>Use the checkbox to graph the power function <m>y = x^3</m>.</p>
           <p>Now use the slider to zoom out, and observe the shape of the graph.</p>
           <p>After zooming out, how do the graphs of <m>y = x(x+3)(x-4)</m> and <m>y = x^3</m> compare to each other?</p>
@@ -114,6 +115,7 @@
 
           <pg-code>
             $function=PopUp(["?","x^2","x^3","x^4","x^5"],"x^4");
+            $ggb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/Swe8tMPk/width/416/height/373/border/888888" width="416px" height="373px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
           </pg-code>
         <statement>
           <p>There is a lot going on in the following graph.</p>
@@ -124,7 +126,7 @@
           <mrow>y \amp= x^4</mrow>
           <mrow>y \amp= x^5</mrow></md></p>
           <p>Before maniuplating the graph, make a guess:  Which of these power functions will the function <m>g(x)</m> resemble if we zoom out?</p>
-          <p>[@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/Swe8tMPk/width/416/height/373/border/888888" width="416px" height="373px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*</p>
+          <p><var name="$ggb" data="pgml"/></p>
           <p>Make your choice from among the power functions by selecting its checkbox. Then, use the slider to zoom out.</p>
           <p>If you guessed correctly, the graph of <m>g(x)</m> will begin to look more and more like your power function.</p>
           <p>Which power function has the same end behavior as <m>g(x)</m>?</p>
@@ -184,10 +186,11 @@
             $left=PopUp(["?","Up","Down"],"Down");
             $right=PopUp(["?","Up","Down"],"Up");
             $end=PopUp(["?","x","x^2","x^3"],"x^3");
+            $ggb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/NcwafvMp/width/427/height/392/border/888888" width="427px" height="392px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
           </pg-code>
         <statement>
           <p>This problem concerns the polynomial <me>f(x) = x(x - 2)(x + 3)</me>and your goal is to predict the end-behavior. Think about the power function which has the same end-behavior as <m>f(x)</m>.</p>
-          <p>[@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/NcwafvMp/width/427/height/392/border/888888" width="427px" height="392px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*</p>
+          <p><var name="$ggb" data="pgml"/></p>
           <p>Use the checkboxes to choose whether the graph will point upward or downward as <m>x</m> gets far from zero on the left and right.</p>
           <p>On the left-hand side, the graph points <var name="$left" form="popup" /></p>
           <p>On the right-hand side, the graph points <var name="$right" form="popup" /></p>

--- a/src/activity-exponential-intro.xml
+++ b/src/activity-exponential-intro.xml
@@ -310,7 +310,7 @@
 
             <p>
               A percent increase implies the growth factor
-              <m>b = 1 + r</m>, (<init>i.e.</init> <m>b \gt 1</m>) while a percent decrease implies <m>b=1-r</m>, (<init>i.e.</init> <m>0 \lt b \lt 1)</m>.
+              <m>b = 1 + r</m>, (i.e.<nbsp/><m>b \gt 1</m>) while a percent decrease implies <m>b=1-r</m>, (i.e.<nbsp/><m>0 \lt b \lt 1)</m>.
             </p>
 
             <p>
@@ -512,7 +512,7 @@
   </subsection>
 
   <subsection>
-    <title>Linear <init>vs.</init> Exponential Patterns</title>
+    <title>Linear vs.<nbsp/>Exponential Patterns</title>
     <p>
       Looking at data, lists of numbers,
       is related to almost every profession.
@@ -2794,7 +2794,7 @@
             </p>
 
             <p>
-              What is the equation for the horizontal axis (<init>i.e.</init> a line that is zero units high)?
+              What is the equation for the horizontal axis (i.e.<nbsp/>a line that is zero units high)?
             </p>
 
             <p>

--- a/src/activity-exponential-intro.xml
+++ b/src/activity-exponential-intro.xml
@@ -2461,6 +2461,7 @@
                 );
                 $a=Real(25);
                 @time=map{$dInit-$a*$_}(0..6);
+                $ggb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/ZEDrTGWZ/width/431/height/350/border/888888/smb/false/stb/false/stbh/false/ai/false/asb/false/sri/false/rc/false/ld/false/sdz/false/ctl/false" width="431px" height="350px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
             </pg-code>
           <statement>
             <p>
@@ -2529,7 +2530,7 @@
 
                 <li>
                   <p>
-                    [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/ZEDrTGWZ/width/431/height/350/border/888888/smb/false/stb/false/stbh/false/ai/false/asb/false/sri/false/rc/false/ld/false/sdz/false/ctl/false" width="431px" height="350px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+                    <var name="$ggb" data="pgml"/>
                   </p>
 
                   <p>
@@ -2574,6 +2575,7 @@
                 $r=Real(0.25);
                 $b=1-$r;
                 @t2=map{$dInit*$b**$_}(0..6);
+                $ggb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/bu2AzCg2/width/361/height/330/border/888888/smb/false/stb/false/stbh/false/ai/false/asb/false/sri/false/rc/false/ld/false/sdz/false/ctl/false" width="361px" height="330px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
             </pg-code>
           <statement>
             <p>
@@ -2638,7 +2640,7 @@
 
                 <li>
                   <p>
-                    [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/bu2AzCg2/width/361/height/330/border/888888/smb/false/stb/false/stbh/false/ai/false/asb/false/sri/false/rc/false/ld/false/sdz/false/ctl/false" width="361px" height="330px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+                    <var name="$ggb" data="pgml"/>
                   </p>
 
                   <p>
@@ -2696,6 +2698,9 @@
       </introduction>
 
       <webwork>
+        <pg-code>
+          $ggb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/KgnNyQjd/width/457/height/338/border/888888/smb/false/stb/false/stbh/false/ai/false/asb/false/sri/false/rc/false/ld/false/sdz/false/ctl/false" width="457px" height="338px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
+        </pg-code>
           <stage>
           <statement>
             <p>
@@ -2779,7 +2784,7 @@
           <stage>
           <statement>
             <p>
-              [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/KgnNyQjd/width/457/height/338/border/888888/smb/false/stb/false/stbh/false/ai/false/asb/false/sri/false/rc/false/ld/false/sdz/false/ctl/false" width="457px" height="338px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+              <var name="$ggb" data="pgml"/>
             </p>
 
             <p>

--- a/src/activity-function-notation.xml
+++ b/src/activity-function-notation.xml
@@ -296,6 +296,7 @@
                 if($envir{problemSeed}==1){$time=2;};
                 $position = Real(40*exp(2.6*($time-2))/(1+exp(2.6*($time-2)))+10);
                 $units = PopUp(["?", "miles", "hours", "miles per hour", "hours per mile"], "miles");
+                $ggb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/D4s2v4ft/width/450/height/459/border/888888/rc/false/ai/false/sdz/false/smb/false/stb/false/stbh/true/ld/false/sri/false/at/auto" width="450px" height="459px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
             </pg-code>
           <statement>
             <p>
@@ -315,7 +316,7 @@
             </p>
 
             <p>
-              [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/D4s2v4ft/width/450/height/459/border/888888/rc/false/ai/false/sdz/false/smb/false/stb/false/stbh/true/ld/false/sri/false/at/auto" width="450px" height="459px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+              <var name="$ggb" data="pgml"/>
             </p>
 
             <p>
@@ -636,6 +637,7 @@
                 Context()->flags->set(formatStudentAnswer=>"parsed");
                 $f2=Formula("f(2)");
                 $evf2=$f2->cmp()->withPostFilter(AnswerHints(Compute("30") => "That's the actual value, but respond by using function notation."));
+                $ggb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/P6uUYQqH/width/402/height/499/border/888888/rc/false/ai/false/sdz/false/smb/false/stb/false/stbh/true/ld/false/sri/false/at/auto" width="402px" height="499px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
             </pg-code>
           <statement>
             <p>
@@ -651,7 +653,7 @@
             </p>
 
             <p>
-              [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/P6uUYQqH/width/402/height/499/border/888888/rc/false/ai/false/sdz/false/smb/false/stb/false/stbh/true/ld/false/sri/false/at/auto" width="402px" height="499px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+              <var name="$ggb" data="pgml"/>
             </p>
 
             <p>
@@ -1105,6 +1107,8 @@
             <pg-code>
               $nopass = RadioButtons(["This graph is a function","This graph is not a function"],1);
               $pass = RadioButtons(["This graph is a function","This graph is not a function"],0);
+              $ggb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/QTfyBkEb/width/413/height/266/border/888888" width="413px" height="266px" style="border:0px;" width="431px" height="313px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
+              $ggb2 = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/Req8ZfCM/width/413/height/290/border/888888" width="413px" height="290px" style="border:0px;" width="431px" height="313px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
             </pg-code>
           <statement>
             <p>
@@ -1116,7 +1120,7 @@
               <ol label="a">
                 <li>
                   <p>
-                    [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/QTfyBkEb/width/413/height/266/border/888888" width="413px" height="266px" style="border:0px;" width="431px" height="313px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+                    <var name="$ggb" data="pgml"/>
                   </p>
 
                   <p>
@@ -1126,7 +1130,7 @@
 
                 <li>
                   <p>
-                    [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/Req8ZfCM/width/413/height/290/border/888888" width="413px" height="290px" style="border:0px;" width="431px" height="313px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+                    <var name="$ggb2" data="pgml"/>
                   </p>
 
                   <p>
@@ -1190,6 +1194,8 @@
                 $none = Real(1);
                 $no = RadioButtons(["Passes Vertical Line Test","Does not pass Vertical Line Test"],1);
                 $yes = RadioButtons(["Passes Vertical Line Test","Does not pass Vertical Line Test"],0);
+                $ggb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/tqS4kTMd/width/413/height/331/border/888888" width="413px" height="331px" style="border:0px;" width="431px" height="313px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
+                $ggb2 = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/zepNEn3W/width/413/height/331/border/888888" width="413px" height="331px" style="border:0px;" width="431px" height="313px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
             </pg-code>
           <statement>
             <p>
@@ -1205,7 +1211,7 @@
               <ol label="a">
                 <li>
                   <p>
-                    [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/tqS4kTMd/width/413/height/331/border/888888" width="413px" height="331px" style="border:0px;" width="431px" height="313px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+                    <var name="$ggb" data="pgml"/>
                   </p>
 
                   <p>
@@ -1215,7 +1221,7 @@
 
                 <li>
                   <p>
-                    [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/zepNEn3W/width/413/height/331/border/888888" width="413px" height="331px" style="border:0px;" width="431px" height="313px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+                    <var name="$ggb2" data="pgml"/>
                   </p>
 
                   <p>
@@ -1400,6 +1406,7 @@
                 $output2 = Real(0);
                 $output3 = Real(0);
                 $output4 = Real(-1.54);
+                $ggb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/AKbM4T7B/width/431/height/415/border/888888/smb/false/stb/false/stbh/false/ai/false/asb/false/sri/false/rc/false/ld/false/sdz/false/ctl/false" width="431px" height="415px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
             </pg-code>
           <statement>
             <p>
@@ -1413,7 +1420,7 @@
             </p>
 
             <p>
-              [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/AKbM4T7B/width/431/height/415/border/888888/smb/false/stb/false/stbh/false/ai/false/asb/false/sri/false/rc/false/ld/false/sdz/false/ctl/false" width="431px" height="415px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+              <var name="$ggb" data="pgml"/>
             </p>
 
             <p>
@@ -1735,7 +1742,10 @@
                 $solutions2 = List(2.64);
                 $maxNumSolutions = 3;
                 $minNumSolutions = 1;
-
+                $ggb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/CPtFHaPP/width/431/height/355/border/888888/smb/false/stb/false/stbh/false/ai/false/asb/false/sri/false/rc/false/ld/false/sdz/false/ctl/false" width="431px" height="355px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
+                $ggb2 = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/CPtFHaPP/width/431/height/355/border/888888/smb/false/stb/false/stbh/false/ai/false/asb/false/sri/false/rc/false/ld/false/sdz/false/ctl/false" width="431px" height="355px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
+                $ggb3 = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/CPtFHaPP/width/431/height/355/border/888888/smb/false/stb/false/stbh/false/ai/false/asb/false/sri/false/rc/false/ld/false/sdz/false/ctl/false" width="431px" height="355px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
+                $ggb4 = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/CPtFHaPP/width/431/height/355/border/888888/smb/false/stb/false/stbh/false/ai/false/asb/false/sri/false/rc/false/ld/false/sdz/false/ctl/false" width="431px" height="355px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
             </pg-code>
           <stage>
           <statement>
@@ -1749,7 +1759,7 @@
             </p>
 
             <p>
-              [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/CPtFHaPP/width/431/height/355/border/888888/smb/false/stb/false/stbh/false/ai/false/asb/false/sri/false/rc/false/ld/false/sdz/false/ctl/false" width="431px" height="355px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+              <var name="$ggb" data="pgml"/>
             </p>
 
             <p>
@@ -1800,7 +1810,7 @@
           <stage>
           <statement>
             <p>
-              [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/CPtFHaPP/width/431/height/355/border/888888/smb/false/stb/false/stbh/false/ai/false/asb/false/sri/false/rc/false/ld/false/sdz/false/ctl/false" width="431px" height="355px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+              <var name="$ggb2" data="pgml"/>
             </p>
 
             <p>
@@ -1832,7 +1842,7 @@
           <stage>
           <statement>
             <p>
-              [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/CPtFHaPP/width/431/height/355/border/888888/smb/false/stb/false/stbh/false/ai/false/asb/false/sri/false/rc/false/ld/false/sdz/false/ctl/false" width="431px" height="355px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+              <var name="$ggb3" data="pgml"/>
             </p>
 
             <p>
@@ -1858,7 +1868,7 @@
           <stage>
           <statement>
             <p>
-              [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/CPtFHaPP/width/431/height/355/border/888888/smb/false/stb/false/stbh/false/ai/false/asb/false/sri/false/rc/false/ld/false/sdz/false/ctl/false" width="431px" height="355px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+              <var name="$ggb4" data="pgml"/>
             </p>
 
             <p>
@@ -1988,6 +1998,7 @@
                    my ($correct,$student,$ansHash) = @_;
                    return (($student = $b)?1:0);
                  });
+                 $ggb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/rZySMTyJ/width/413/height/331/border/888888" width="413px" height="331px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
             </pg-code>
           <statement>
             <p>
@@ -2011,7 +2022,7 @@
             </p>
 
             <p>
-              [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/rZySMTyJ/width/413/height/331/border/888888" width="413px" height="331px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+              <var name="$ggb" data="pgml"/>
             </p>
 
             <p>

--- a/src/activity-function-notation.xml
+++ b/src/activity-function-notation.xml
@@ -311,7 +311,7 @@
               Adjust the time by sliding cross-hairs left and right.
               Notice that the train's distance, in miles,
               from downtown depends on the time, in hours,
-              after <m>8</m> <init>a.m.</init>
+              after <m>8</m> <am/>
             </p>
 
             <p>
@@ -319,7 +319,7 @@
             </p>
 
             <p>
-              How far from downtown is the train <m><var name="$time" /></m> hours after <m>8</m> <init>a.m.</init>?
+              How far from downtown is the train <m><var name="$time" /></m> hours after <m>8</m> <am/>?
             </p>
 
             <p>
@@ -395,7 +395,7 @@
 
     <blockquote>
       <p>
-        <m>2</m> hours after <m>8</m> <init>a.m.</init> the train is <m>30</m> miles from downtown.
+        <m>2</m> hours after <m>8</m> <am/> the train is <m>30</m> miles from downtown.
       </p>
     </blockquote>
 
@@ -450,7 +450,7 @@
       so we can let the dependent variable <m>D</m> represent the
       <q>Train's distance in miles from downtown</q>.
       Similarly, we can use the independent variable <m>t</m> to represent the
-      <q>number of hours after <m>8</m> <init>a.m.</init></q>.
+      <q>number of hours after <m>8</m> <am/></q>.
     </p>
 
     <p>
@@ -600,14 +600,14 @@
         f(\text{input}) = \mathit{output}
       </me>
       The function notation <m>f(0)</m> is telling us the input is <m>0</m>.
-      That means, <q><m>0</m> hours after <m>8</m> <init>a.m.</init></q> In other words,
-      it's <m>8</m> <init>a.m.</init>
+      That means, <q><m>0</m> hours after <m>8</m> <am/></q> In other words,
+      it's <m>8</m> <am/>
     </p>
 
     <p>
       On the other hand, <m>f(0)</m> represents an output.
       It is <q>the train's distance from downtown,
-      <m>0</m> hours after <m>8</m> <init>a.m.</init></q>
+      <m>0</m> hours after <m>8</m> <am/></q>
       But we don't know what that distance actually is yet.
       In this case, the notation <m>f(0)</m> means
       <q>Whatever the distance is at t = 0</q>.
@@ -629,7 +629,7 @@
                 $distance = Real(10);
                 $units = PopUp(["?", "miles", "hours", "miles per hour", "hours per mile"], "miles");
                 $start = 8;
-                $ampm = PopUp(["?", "a.m.", "p.m."], "a.m.");
+                $ampm = PopUp(["?", "AM", "PM"], 1);
                 $meanings = PopUp(["?", "the initial position of the train", "the final position of the train", "the distance is zero", "the distance times zero"], 1);
                 parserFunction("f(x)"=>"(sin(x)+2)/pi");
                 Context()->flags->set(reduceConstantFunctions=>0);
@@ -641,8 +641,8 @@
             <p>
               The graph below is a function that illustrates a train's distance from downtown,
               in miles,
-              as a function of time in hours after <m>8</m> <init>a.m.</init> When using a graph the best you can do is estimate.
-              Since <m>f(0)</m> represents a distance at <m>8</m> <init>a.m.</init>,
+              as a function of time in hours after <m>8</m> <am/> When using a graph the best you can do is estimate.
+              Since <m>f(0)</m> represents a distance at <m>8</m> <am/>,
               we can use the graph to find what the distance is.
             </p>
 
@@ -678,7 +678,7 @@
 
             <p>
               How would you represent the statement,
-              <q>train's distance at <m>10</m> <init>a.m.</init></q> using function notation?
+              <q>train's distance at <m>10</m> <am/></q> using function notation?
             </p>
 
             <p>
@@ -1232,7 +1232,7 @@
   <subsection>
     <title>Evaluate</title>
     <p>
-      It is one thing to talk about <q>The train's distance from downtown <m>2</m> hours after <m>8</m> <init>a.m.</init></q>
+      It is one thing to talk about <q>The train's distance from downtown <m>2</m> hours after <m>8</m> <am/></q>
       and a completely different thing to say what that distance actually is.
     </p>
 
@@ -1242,7 +1242,7 @@
           <idx><h>function</h><h>evaluation</h></idx>
       means <q>use an input value in order to find an output value.</q> Therefore,
       evaluating <m>f(2)</m> in our train example means
-      <q>Find the value of the train's distance from downtown <m>2</m> hours after <m>8</m> <init>a.m.</init></q>
+      <q>Find the value of the train's distance from downtown <m>2</m> hours after <m>8</m> <am/></q>
     </p>
 
     <p>
@@ -1267,7 +1267,7 @@
                 <col halign="center"/>
                 <col halign="center"/>
                 <row>
-                  <cell><m>t</m> (hours after <m>8</m> <init>a.m.</init>)</cell>
+                  <cell><m>t</m> (hours after <m>8</m> <am/>)</cell>
                   <cell><m>D = f(t)</m> (miles from downtown)</cell>
                 </row>
                 <row>
@@ -1707,7 +1707,7 @@
 
     <p>
       You could answer the question with actual times if you had a
-      <em>time <init>vs.</init> temperature</em> graph,
+      <em>time vs.<nbsp/>temperature</em> graph,
       or a formula, or a table of times and temperatures.
     </p>
 

--- a/src/activity-inverse.xml
+++ b/src/activity-inverse.xml
@@ -754,6 +754,7 @@
           $point1=PopUp(["?",'(0, 3)','(3, 0)'],2);
           $point2=PopUp(["?",'(-1, -2)','(-2, -1)'],1);
           $correct=PopUp(["?","Yes","No"],1);
+          $ggb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/hABCSSG2/width/431/height/372/border/888888/sdz/false/" width="431px" height="372px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
         </pg-code>
         <statement>
           <p>
@@ -763,7 +764,7 @@
           </p>
 
           <p>
-            [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/hABCSSG2/width/431/height/372/border/888888/sdz/false/" width="431px" height="372px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+            <var name="$ggb" data="pgml"/>
           </p>
 
           <p>
@@ -858,6 +859,8 @@
               2, labels => ["Reflect over x-axks","Reflect over y-axis","Reflect over y = x"],
               displayLabels => 0
           );
+          $ggb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/rz4JeYK4/width/434/height/372/border/888888/sdz/false/" width="434px" height="372px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
+          $ggb2 = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/ceba23wQ/width/429/height/371/border/888888/sdz/false/" width="429px" height="371px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
         </pg-code>
         <statement>
           <p>
@@ -867,7 +870,7 @@
           </p>
 
           <p>
-            [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/rz4JeYK4/width/434/height/372/border/888888/sdz/false/" width="434px" height="372px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+            <var name="$ggb" data="pgml"/>
           </p>
 
           <p>
@@ -877,7 +880,7 @@
           </p>
 
           <p>
-            [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/ceba23wQ/width/429/height/371/border/888888/sdz/false/" width="429px" height="371px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+            <var name="$ggb2" data="pgml"/>
           </p>
 
           <p>
@@ -1155,6 +1158,8 @@
         <pg-code>
           $non=PopUp(['?','A horizontal line never intersects the graph more than once.','A horizontal line may intersect the graph more than once.'],2);
           $inv=PopUp(['?','A horizontal line never intersects the graph more than once.','A horizontal line may intersect the graph more than once.'],1);
+          $ggb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/baHXJZNh/width/432/height/373/border/888888/sdz/false/" width="432px" height="373px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
+          $ggb2 = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/sfMbwrsn/width/425/height/373/border/888888/sdz/false/" width="425px" height="373px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
         </pg-code>
         <statement>
           <p>
@@ -1162,7 +1167,7 @@
           </p>
 
           <p>
-            [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/baHXJZNh/width/432/height/373/border/888888/sdz/false/" width="432px" height="373px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+            <var name="$ggb" data="pgml"/>
           </p>
 
           <p>
@@ -1176,7 +1181,7 @@
           </p>
 
           <p>
-            [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/sfMbwrsn/width/425/height/373/border/888888/sdz/false/" width="425px" height="373px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+            <var name="$ggb2" data="pgml"/>
           </p>
 
           <p>

--- a/src/activity-logarithmic-functions.xml
+++ b/src/activity-logarithmic-functions.xml
@@ -1734,7 +1734,7 @@
         <me>
           \log_2(8\cdot16)=\log_2(128)\text{.}
         </me>
-        Notice on the right side we already know the answer (<init>i.e.</init> the power of <m>2</m> that gives you <m>128</m>)
+        Notice on the right side we already know the answer (i.e.<nbsp/>the power of <m>2</m> that gives you <m>128</m>)
       </p>
 
       <exercise>

--- a/src/activity-logarithmic-functions.xml
+++ b/src/activity-logarithmic-functions.xml
@@ -492,13 +492,14 @@
                 if($envir{problemSeed}==1){$b=36;$c=0.6;};
                 $answer=Real(ln($b)/ln(10));
                 $answer2=Real(ln($c)/ln(10));
+                $ggb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/SPx8Srb3/width/431/height/275/border/888888/smb/false/stb/false/stbh/false/ai/false/asb/false/sri/false/rc/false/ld/false/sdz/false/ctl/false" width="431px" height="275px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
             </pg-code>
           <statement>
             <p>
               We wish to solve the equation <m><var name="$a"/>^x=<var name="$b"/></m>.
               To that end, examine the graph:
             </p>
-            <!-- <p>[@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/SPx8Srb3/width/431/height/275/border/888888/smb/false/stb/false/stbh/false/ai/false/asb/false/sri/false/rc/false/ld/false/sdz/false/ctl/false" width="431px" height="275px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*</p> -->
+            <!-- <p><var name="$ggb" data="pgml"/></p> -->
             <p>
               Click on this link to
               <url href="https://www.desmos.com/calculator/soxcvqkg9i">Desmos.com</url>
@@ -1300,6 +1301,9 @@
     <exercise>
       <title>Graph of <m>f(x)=\log_{2}(x)</m></title>
       <webwork>
+        <pg-code>
+          $ggb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/mJYWSCfb/width/431/height/300/border/888888/smb/false/stb/false/stbh/false/ai/false/asb/false/sri/false/rc/false/ld/false/sdz/false/ctl/false" width="431px" height="300px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
+        </pg-code>
           <statement>
             <p>
               <m>\log_{2}</m> is <q>Log base <m>2</m></q>
@@ -1355,7 +1359,7 @@
               </tabular>
 
             <p>
-              [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/mJYWSCfb/width/431/height/300/border/888888/smb/false/stb/false/stbh/false/ai/false/asb/false/sri/false/rc/false/ld/false/sdz/false/ctl/false" width="431px" height="300px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+              <var name="$ggb" data="pgml"/>
             </p>
 
             <p>
@@ -1369,6 +1373,9 @@
     <exercise>
       <title>Zoom in on <m>f(x)=\log_{2}(x)</m> for small values of <m>x</m></title>
       <webwork>
+        <pg-code>
+          $ggb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/MrhswJHV/width/431/height/360/border/888888/smb/false/stb/false/stbh/false/ai/false/asb/false/sri/false/rc/false/ld/false/sdz/false/ctl/false" width="431px" height="360px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
+        </pg-code>
           <statement>
             <p>
               <m>\log_{2}</m> is <q>Log base <m>2</m></q>
@@ -1420,7 +1427,7 @@
               </tabular>
 
             <p>
-              [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/MrhswJHV/width/431/height/360/border/888888/smb/false/stb/false/stbh/false/ai/false/asb/false/sri/false/rc/false/ld/false/sdz/false/ctl/false" width="431px" height="360px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+              <var name="$ggb" data="pgml"/>
             </p>
 
             <p>
@@ -1449,10 +1456,11 @@
                 ["\(\log(6.1)\)","\(\log_{2}(6.1)\)"],
                 1, labels => ["log(x)","log2(x)"],displayLabels => 0
                 );
+                $ggb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/RdRRdBJM/width/431/height/360/border/888888/smb/false/stb/false/stbh/false/ai/false/asb/false/sri/false/rc/false/ld/false/sdz/false/ctl/false" width="431px" height="360px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
             </pg-code>
           <statement>
             <p>
-              [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/RdRRdBJM/width/431/height/360/border/888888/smb/false/stb/false/stbh/false/ai/false/asb/false/sri/false/rc/false/ld/false/sdz/false/ctl/false" width="431px" height="360px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+              <var name="$ggb" data="pgml"/>
             </p>
 
             <p>

--- a/src/activity-periodic-functions.xml
+++ b/src/activity-periodic-functions.xml
@@ -26,7 +26,7 @@
             <pg-code>
               $timeToCharge=Real(6);
               $beginCharging=PopUp(
-              ["?","12:00 A.M.","6:00 A.M.","12:00 P.M.","6:00 P.M."],"6:00 P.M."
+              ["?","12:00 AM","6:00 AM","12:00 PM","6:00 PM"],4
               );
               $period=Real(24);
             </pg-code>
@@ -94,7 +94,7 @@
 
                 <li>
                   <p>
-                    The user begins recharging the phone at <m>6:00</m> P.M. each day.
+                    The user begins recharging the phone at <m>6:00</m> <pm/> each day.
                   </p>
                 </li>
 

--- a/src/activity-periodic-functions.xml
+++ b/src/activity-periodic-functions.xml
@@ -29,6 +29,7 @@
               ["?","12:00 AM","6:00 AM","12:00 PM","6:00 PM"],4
               );
               $period=Real(24);
+              $ggb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/P6hCb2sn/width/425/height/343/border/888888/sri/true/sdz/false/" width="425px" height="343px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
             </pg-code>
           <statement>
             <p>
@@ -38,7 +39,7 @@
             </p>
 
             <p>
-              [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/P6hCb2sn/width/425/height/343/border/888888/sri/true/sdz/false/" width="425px" height="343px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+              <var name="$ggb" data="pgml"/>
             </p>
 
             <p>
@@ -228,6 +229,7 @@
               $vertStretch=PopUp(["?","Changing the radius of the wheel","Changing the platform height","Changing the period"],"Changing the radius of the wheel");
               $vertShift=PopUp(["?","Changing the radius of the wheel","Changing the platform height","Changing the period"],"Changing the platform height");
               $horizontalStretch=PopUp(["?","Changing the radius of the wheel","Changing the platform height","Changing the period"],"Changing the period");
+              $ggb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/CKBXG9gF/width/425/height/429/border/888888/sri/true/sdz/false/" width="425px" height="429px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
             </pg-code>
           <statement>
             <p>
@@ -236,7 +238,7 @@
             </p>
 
             <p>
-              [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/CKBXG9gF/width/425/height/429/border/888888/sri/true/sdz/false/" width="425px" height="429px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+              <var name="$ggb" data="pgml"/>
             </p>
 
             <p>
@@ -585,6 +587,7 @@
               Context()->variables->are(y=>'Real');
               parser::Assignment->Allow;
               $midline=Formula("y=40");
+              $ggb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/tm9RnWCc/width/425/height/373/border/888888/sri/true/sdz/false/" width="425px" height="373px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
             </pg-code>
           <stage>
           <statement>
@@ -710,7 +713,7 @@
             </p>
 
             <p>
-              [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/tm9RnWCc/width/425/height/373/border/888888/sri/true/sdz/false/" width="425px" height="373px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+              <var name="$ggb" data="pgml"/>
             </p>
 
             <p>

--- a/src/activity-piecewise.xml
+++ b/src/activity-piecewise.xml
@@ -103,11 +103,14 @@
               $answer1 = Compute("-8&lt;=x&lt;=-3");
               $answer2 = Compute("-3&lt;=x&lt;=2");
               $answer3 = Compute("2&lt;x&lt;=8");
+              $gbb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/QeJS3ygG/width/431/height/313/border/888888/sri/true" width="431px" height="313px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
+              $gbb2 = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/QeJS3ygG/width/431/height/313/border/888888/sri/true" width="431px" height="313px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
+              $gbb3 = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/QeJS3ygG/width/431/height/313/border/888888/sri/true" width="431px" height="313px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
          </pg-code>
           <stage>
           <statement>
             <p>
-              [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/QeJS3ygG/width/431/height/313/border/888888/sri/true" width="431px" height="313px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+              <var name="$ggb" data="pgml"/>
             </p>
 
             <p>
@@ -185,7 +188,7 @@
           <stage>
           <statement>
             <p>
-              [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/QeJS3ygG/width/431/height/313/border/888888/sri/true" width="431px" height="313px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+              <var name="$ggb2" data="pgml"/>
             </p>
 
             <p>
@@ -221,7 +224,7 @@
           <stage>
           <statement>
             <p>
-              [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/QeJS3ygG/width/431/height/313/border/888888/sri/true" width="431px" height="313px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+              <var name="$ggb3" data="pgml"/>
             </p>
 
             <p>
@@ -324,11 +327,12 @@
               $answer1 = Compute("-8&lt;=x&lt;=-3");
               $answer2 = Compute("-3&lt;=x&lt;=2");
               $answer3 = Compute("2&lt;x&lt;=8");
+              $gbb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/QeJS3ygG/width/431/height/313/border/888888/sri/true" width="431px" height="313px" style="border:0px;" width="431px" height="313px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
           </pg-code>
           <stage>
           <statement>
             <p>
-              [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/QeJS3ygG/width/431/height/313/border/888888/sri/true" width="431px" height="313px" style="border:0px;" width="431px" height="313px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+              <var name="$ggb" data="pgml"/>
             </p>
 
             <p>
@@ -573,6 +577,10 @@
 
             <pg-code>
               $answer1 = Real(1);
+              $gbb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/NJjzus4k/width/431/height/325/border/888888/sri/true" width="431px" height="325px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
+              $gbb2 = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/q2YkKFP5/width/431/height/325/border/888888/sri/true" width="431px" height="325px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
+              $gbb3 = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/FNk3SwS4/width/431/height/325/border/888888/sri/true" width="431px" height="325px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
+              $gbb4 = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/r4MTsAXb/width/431/height/325/border/888888/sri/true" width="431px" height="325px" style="border:0px;" width="431px" height="313px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
             </pg-code>
           <statement>
             <p>
@@ -584,7 +592,7 @@
             </p>
 
             <p>
-              [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/NJjzus4k/width/431/height/325/border/888888/sri/true" width="431px" height="325px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+              <var name="$ggb" data="pgml"/>
             </p>
 
             <p>
@@ -592,7 +600,7 @@
             </p>
 
             <p>
-              [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/q2YkKFP5/width/431/height/325/border/888888/sri/true" width="431px" height="325px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+              <var name="$ggb2" data="pgml"/>
             </p>
 
             <p>
@@ -600,7 +608,7 @@
             </p>
 
             <p>
-              [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/FNk3SwS4/width/431/height/325/border/888888/sri/true" width="431px" height="325px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+              <var name="$ggb3" data="pgml"/>
             </p>
 
             <p>
@@ -638,7 +646,7 @@
             </p>
 
             <p>
-              [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/r4MTsAXb/width/431/height/325/border/888888/sri/true" width="431px" height="325px" style="border:0px;" width="431px" height="313px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+              <var name="$ggb4" data="pgml"/>
             </p>
           </statement>
       </webwork>

--- a/src/activity-polynomials.xml
+++ b/src/activity-polynomials.xml
@@ -222,6 +222,7 @@
             $degree2=Real(2);
             Context("LimitedPolynomial");
             $formula=Formula("x^2-x-2");
+            $gbb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/ZQ4DEqee/width/432/height/373/border/888888/sdz/false/" width="432px" height="373px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
           </pg-code>
           <statement>
             <p>
@@ -232,7 +233,7 @@
             </p>
 
             <p>
-              [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/ZQ4DEqee/width/432/height/373/border/888888/sdz/false/" width="432px" height="373px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+              <var name="$ggb" data="pgml"/>
             </p>
 
             <p>
@@ -324,10 +325,11 @@
 
           <pg-code>
             $rootsWhere=PopUp(["?","It has both roots of the linear functions.","It has different roots than the linear functions.","Roots? There are no roots."],1);
+            $gbb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/ZQ4DEqee/width/432/height/373/border/888888/sdz/false/" width="432px" height="373px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
           </pg-code>
           <statement>
             <p>
-              [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/ZQ4DEqee/width/432/height/373/border/888888/sdz/false/" width="432px" height="373px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+              <var name="$ggb" data="pgml"/>
             </p>
 
             <p>
@@ -369,6 +371,7 @@
             $root1=Real(1);
             $root0=Real(0);
             $rootsAll=PopUp(["?","All the roots of f, g and h","None of the roots of f, g or h","Roots? There are no roots!"],1);
+            $gbb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/aBfjCKXg/width/433/height/373/border/888888/sdz/false/" width="433px" height="373px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
           </pg-code>
           <statement>
             <p>
@@ -379,7 +382,7 @@
             </p>
 
             <p>
-              [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/aBfjCKXg/width/433/height/373/border/888888/sdz/false/" width="433px" height="373px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+              <var name="$ggb" data="pgml"/>
             </p>
 
             <p>
@@ -577,6 +580,7 @@
 
           <pg-code>
             $didItGraph=PopUp(["?","yes","no"],"yes");
+            $gbb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/VkKRBCpF/width/425/height/373/border/888888/sdz/false/" width="425px" height="373px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
           </pg-code>
           <statement>
             <p>
@@ -585,7 +589,7 @@
             </p>
 
             <p>
-              [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/VkKRBCpF/width/425/height/373/border/888888/sdz/false/" width="425px" height="373px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+              <var name="$ggb" data="pgml"/>
             </p>
 
             <p>
@@ -884,6 +888,7 @@
             $endBehavior=PopUp(["?","end behavior"],"end behavior");
             $power=PopUp(["?","x^2","x^3"],"x^3");
             $term=Compute("x^3");
+            $gbb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/Abx2UAXB/width/425/height/373/border/888888/sdz/false/" width="425px" height="373px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
           </pg-code>
           <statement>
             <p>
@@ -894,7 +899,7 @@
             </p>
 
             <p>
-              [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/Abx2UAXB/width/425/height/373/border/888888/sdz/false/" width="425px" height="373px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+              <var name="$ggb" data="pgml"/>
             </p>
 
             <p>
@@ -954,6 +959,7 @@
 
           <pg-code>
             $function=PopUp(["?","x^2","x^3","x^4","x^5"],"x^4");
+            $gbb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/Swe8tMPk/width/416/height/373/border/888888/sdz/false/" width="416px" height="373px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
           </pg-code>
           <statement>
             <p>
@@ -994,7 +1000,7 @@
             </p>
 
             <p>
-              [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/Swe8tMPk/width/416/height/373/border/888888/sdz/false/" width="416px" height="373px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+              <var name="$ggb" data="pgml"/>
             </p>
 
             <p>
@@ -1176,6 +1182,7 @@
             $left=PopUp(["?","Up","Down"],"Down");
             $right=PopUp(["?","Up","Down"],"Up");
             $end=PopUp(["?","x","x^2","x^3"],"x^3");
+            $gbb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/NcwafvMp/width/427/height/392/border/888888/sdz/false/" width="427px" height="392px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
           </pg-code>
           <statement>
             <p>
@@ -1188,7 +1195,7 @@
             </p>
 
             <p>
-              [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/NcwafvMp/width/427/height/392/border/888888/sdz/false/" width="427px" height="392px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+              <var name="$ggb" data="pgml"/>
             </p>
 
             <p>
@@ -1886,6 +1893,7 @@
             $bounce=PopUp(["?","crosses over","bounces off"],"bounces off");
             $horizontal=PopUp(["?","more horizontal","more vertical"],"more horizontal");
             $root=Real(1);
+            $gbb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/aysca3Xq/width/425/height/373/border/888888/sdz/false/" width="425px" height="373px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
           </pg-code>
           <statement>
             <p>
@@ -1896,7 +1904,7 @@
             </p>
 
             <p>
-              [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/aysca3Xq/width/425/height/373/border/888888/sdz/false/" width="425px" height="373px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+              <var name="$ggb" data="pgml"/>
             </p>
 
             <p>
@@ -1966,6 +1974,7 @@
             $end5=PopUp(["?","x^5","x^6","x^7","x^8"],"x^7");
             $crosses=PopUp(["?","crosses over","bounces off"],"crosses over");
             $horizontal=PopUp(["?","vertical","horizontal"],"horizontal");
+            $gbb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/BZWTYcmb/width/425/height/373/border/888888/sdz/false/" width="425px" height="373px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
           </pg-code>
           <statement>
             <p>
@@ -1976,7 +1985,7 @@
             </p>
 
             <p>
-              [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/BZWTYcmb/width/425/height/373/border/888888/sdz/false/" width="425px" height="373px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+              <var name="$ggb" data="pgml"/>
             </p>
 
             <p>

--- a/src/activity-polynomials.xml
+++ b/src/activity-polynomials.xml
@@ -209,8 +209,8 @@
     </exercise>
 
     <p>
-      Now, we will see how our knowledge of first degree polynomials (<init>a.k.a.</init>
-      <em>lines</em>) will help us to understand polynomials of higher degrees.
+      Now, we will see how our knowledge of first degree polynomials (a.k.a.<nbsp/><em>lines</em>)
+      will help us to understand polynomials of higher degrees.
     </p>
 
     <exercise>

--- a/src/activity-power-functions.xml
+++ b/src/activity-power-functions.xml
@@ -151,6 +151,7 @@
             $evenExponent=PopUp(["?",'points upward on the right and downward on the left','points upward on the right and the left'],2);
             $oddExponent=PopUp(["?",'points upward on the right and downward on the left','points upward on the right and the left'],1);
             $commonPoints=PopUp(["?",'(-1,1)','(0,0) and (1,1)','(-1,-1) and (0,0) and (1,1)'],2);
+            $ggb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/ECrUf9u9/width/425/height/373/border/888888/sdz/false/" width="425px" height="373px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
           </pg-code>
         <statement>
           <p>
@@ -160,7 +161,7 @@
           </p>
 
           <p>
-            [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/ECrUf9u9/width/425/height/373/border/888888/sdz/false/" width="425px" height="373px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+            <var name="$ggb" data="pgml"/>
           </p>
 
           <p>
@@ -518,6 +519,7 @@
             $evenExponent=PopUp(["?",'points upward on both sides','points in opposite directions'],1);
             $oddExponent=PopUp(["?",'points upward on both sides','points in opposite directions'],2);
             $commonPoints=PopUp(["?",'(1,1)','(1,1) and (-1,1)'],1);
+            $ggb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/PAjZ6WxB/width/417/height/349/border/888888/sdz/false/" width="417px" height="349px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
           </pg-code>
         <statement>
           <p>
@@ -527,7 +529,7 @@
           </p>
 
           <p>
-            [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/PAjZ6WxB/width/417/height/349/border/888888/sdz/false/" width="417px" height="349px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+            <var name="$ggb" data="pgml"/>
           </p>
 
           <p>
@@ -847,6 +849,7 @@
             $evenExponent=PopUp(["?",'all real numbers',"x greater than or equal to 0"],2);
             $oddExponent=PopUp(["?",'all real numbers',"x greater than or equal to 0"],1);
             $commonPoints=PopUp(["?",'(-1,-1) and (0,0)','(0,0) and (1,1)'],2);
+            $ggb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/PGyGRyHg/width/417/height/349/border/888888/sdz/false/" width="417px" height="349px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
           </pg-code>
         <statement>
           <p>
@@ -856,7 +859,7 @@
           </p>
 
           <p>
-            [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/PGyGRyHg/width/417/height/349/border/888888/sdz/false/" width="417px" height="349px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+            <var name="$ggb" data="pgml"/>
           </p>
 
           <p>

--- a/src/activity-rational-functions.xml
+++ b/src/activity-rational-functions.xml
@@ -47,8 +47,8 @@
   <subsection>
     <title>Rational Function Definition</title>
     <p>
-      Basically, a <term>rational funciton</term>
-          <idx><h>rational funciton</h></idx>
+      Basically, a <term>rational function</term>
+          <idx><h>rational function</h></idx>
       is a ratio
       (fraction).
       It is composed of a numerator and a denominator in which both are polynomials.
@@ -98,7 +98,7 @@
     <p>
       Notice the definition states specifically that the ratio is made up of polynomials.
       That is important to remember.
-      The functions listed below are NOT rational funcitons because either the numerator or the denominator is not a polynomial.
+      The functions listed below are NOT rational functions because either the numerator or the denominator is not a polynomial.
     </p>
 
     <example>
@@ -559,7 +559,7 @@
     <title>Long Run Behavior</title>
     <p>
       Rational Functions have distinctive behaviors for inputs far from the origin versus inputs close to the origin.
-      When consider the characteristics of a funciton when the inputs are far from the origin,
+      When consider the characteristics of a function when the inputs are far from the origin,
       we call it <term>long-run behavior</term>.
           <idx><h>long-run behavior</h></idx>
     </p>

--- a/src/activity-reflections.xml
+++ b/src/activity-reflections.xml
@@ -163,10 +163,11 @@
                 1, labels => ["True","False"],
                 displayLabels => 0
               );
+              $ggb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/rsSg5fd3/width/368/height/261/border/888888/rc/false/ai/false/sdz/false/smb/false/stb/false/stbh/true/ld/false/sri/false/at/auto" width="368px" height="261px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
             </pg-code>
         <statement>
           <p>
-            [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/rsSg5fd3/width/368/height/261/border/888888/rc/false/ai/false/sdz/false/smb/false/stb/false/stbh/true/ld/false/sri/false/at/auto" width="368px" height="261px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+            <var name="$ggb" data="pgml"/>
           </p>
 
           <p>
@@ -436,10 +437,11 @@
               $xaxis=PopUp(
               ["?","x-axis","y-axis"],"x-axis"
               );
+              $ggb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/gGZwgNcU/width/425/height/373/border/888888/sdz/false/" width="425px" height="373px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
             </pg-code>
           <statement>
             <p>
-              [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/gGZwgNcU/width/425/height/373/border/888888/sdz/false/" width="425px" height="373px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+              <var name="$ggb" data="pgml"/>
             </p>
 
             <p>
@@ -512,6 +514,7 @@
               labels => ["y = -sqrt(x)","y = sqrt(-x)"],
               displayLabels => 0
               );
+              $ggb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/daN858tY/width/429/height/334/border/888888/sri/true/sdz/false/" width="431px" height="313px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
             </pg-code>
           <statement>
             <p>
@@ -520,7 +523,7 @@
             </p>
 
             <p>
-              [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/daN858tY/width/429/height/334/border/888888/sri/true/sdz/false/" width="431px" height="313px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+              <var name="$ggb" data="pgml"/>
             </p>
 
             <p>
@@ -643,6 +646,7 @@
               $yaxis=PopUp(
               ["?","x-axis","y-axis"],"y-axis"
               );
+              $ggb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/n3pVCbS7/width/425/height/373/border/888888/sdz/false/" width="425px" height="373px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
             </pg-code>
           <statement>
             <p>
@@ -650,7 +654,7 @@
             </p>
 
             <p>
-              [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/n3pVCbS7/width/425/height/373/border/888888/sdz/false/" width="425px" height="373px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+              <var name="$ggb" data="pgml"/>
             </p>
 
             <p>
@@ -730,6 +734,7 @@
               labels => ["y = -sqrt(x)","y = sqrt(-x)"],
               displayLabels => 0
               );
+              $ggb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/dBskeXZe/width/422/height/257/border/888888/sri/true/sdz/false/" width="422px" height="257px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
             </pg-code>
           <statement>
             <p>
@@ -738,7 +743,7 @@
             </p>
 
             <p>
-              [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/dBskeXZe/width/422/height/257/border/888888/sri/true/sdz/false/" width="422px" height="257px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+              <var name="$ggb" data="pgml"/>
             </p>
 
             <p>
@@ -861,6 +866,7 @@
               $h=PopUp(
               ["?","-f(x)","f(-x)"],"f(-x)"
               );
+              $ggb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/bScMTEdX/width/425/height/373/border/888888/sdz/false/" width="425px" height="373px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
             </pg-code>
           <statement>
             <p>
@@ -868,7 +874,7 @@
             </p>
 
             <p>
-              [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/bScMTEdX/width/425/height/373/border/888888/sdz/false/" width="425px" height="373px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+              <var name="$ggb" data="pgml"/>
             </p>
 
             <p>
@@ -906,6 +912,7 @@
               $a=random(3,12,1);
               $g=Compute("-(x+$a)^4");
               $h=Compute("(-x+$a)^4");
+              $ggb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/bScMTEdX/width/425/height/373/border/888888/sdz/false/" width="425px" height="373px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
             </pg-code>
           <statement>
             <p>
@@ -913,7 +920,7 @@
             </p>
 
             <p>
-              [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/bScMTEdX/width/425/height/373/border/888888/sdz/false/" width="425px" height="373px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+              <var name="$ggb" data="pgml"/>
             </p>
 
             <p>
@@ -980,11 +987,11 @@
       <webwork>
 
             <pg-code>
-
+              $ggb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/MvQnu5Vm/width/425/height/373/border/888888/sdz/false/" width="425px" height="373px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
             </pg-code>
           <statement>
             <p>
-              [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/MvQnu5Vm/width/425/height/373/border/888888/sdz/false/" width="425px" height="373px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+              <var name="$ggb" data="pgml"/>
             </p>
 
             <p>
@@ -1012,11 +1019,11 @@
       <webwork>
 
             <pg-code>
-
+              $ggb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/e6ZcGJS3/width/425/height/373/border/888888/sdz/false/" width="425px" height="373px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
             </pg-code>
           <statement>
             <p>
-              [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/e6ZcGJS3/width/425/height/373/border/888888/sdz/false/" width="425px" height="373px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+              <var name="$ggb" data="pgml"/>
             </p>
 
             <p>

--- a/src/activity-transformations.xml
+++ b/src/activity-transformations.xml
@@ -51,6 +51,7 @@
             $down=PopUp(
             ["?","It went up by 3 units.","It went down by 3 units."],"It went down by 3 units."
             );
+            $ggb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/pXUT7wZS/width/431/height/313/border/888888/sri/true/sdz/false/" width="431px" height="313px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
           </pg-code>
           <statement>
             <p>
@@ -60,7 +61,7 @@
             </p>
 
             <p>
-              [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/pXUT7wZS/width/431/height/313/border/888888/sri/true/sdz/false/" width="431px" height="313px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+              <var name="$ggb" data="pgml"/>
             </p>
 
             <p>
@@ -129,6 +130,7 @@
             $right5down4=PopUp(
             ["?","right 5, and down 4","right 5, and up 4","left 5, and down 4","left 5, and up 4"],"right 5, and down 4"
             );
+            $ggb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/qHkxbUVg/width/430/height/272/border/888888/sri/true/sdz/false/" width="430px" height="272px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
           </pg-code>
           <statement>
             <p>
@@ -138,7 +140,7 @@
             </p>
 
             <p>
-              [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/qHkxbUVg/width/430/height/272/border/888888/sri/true/sdz/false/" width="430px" height="272px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+              <var name="$ggb" data="pgml"/>
             </p>
 
             <p>
@@ -209,6 +211,8 @@
             $xaxis=PopUp(
             ["?","x-axis","y-axis","line y = x"],"x-axis"
             );
+            $ggb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/aSr3RBYV/width/432/height/438/border/888888/sri/true/sdz/false/" width="432px" height="438px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
+            $ggb2 = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/b2KYhMZS/width/433/height/518/border/888888/sri/true/sdz/false/" width="433px" height="518px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
           </pg-code>
           <statement>
             <p>
@@ -217,7 +221,7 @@
             </p>
 
             <p>
-              [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/aSr3RBYV/width/432/height/438/border/888888/sri/true/sdz/false/" width="432px" height="438px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+              <var name="$ggb" data="pgml"/>
             </p>
 
             <p>
@@ -263,7 +267,7 @@
             </p>
 
             <p>
-              [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/b2KYhMZS/width/433/height/518/border/888888/sri/true/sdz/false/" width="433px" height="518px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+              <var name="$ggb2" data="pgml"/>
             </p>
 
             <p>
@@ -691,6 +695,8 @@
             );
             parserFunction("f(x)"=>"(sin(x)+2)/pi");
             $f2=Formula("f(2x)");
+            $ggb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/V52gqJSs/width/425/height/373/border/888888/sri/true/sdz/false/" width="425px" height="373px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
+            $ggb2 = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/sGJWwWxF/width/425/height/373/border/888888/sri/true/sdz/false/" width="425px" height="373px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
           </pg-code>
           <statement>
             <p>
@@ -703,7 +709,7 @@
             </p>
 
             <p>
-              [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/V52gqJSs/width/425/height/373/border/888888/sri/true/sdz/false/" width="425px" height="373px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+              <var name="$ggb" data="pgml"/>
             </p>
 
             <p>
@@ -744,7 +750,7 @@
             </p>
 
             <p>
-              [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/sGJWwWxF/width/425/height/373/border/888888/sri/true/sdz/false/" width="425px" height="373px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+              <var name="$ggb2" data="pgml"/>
             </p>
 
             <p>
@@ -797,10 +803,11 @@
             $twice=RadioButtons(
             ["y = f(2x)","y = f(0.5x)"],1
             );
+            $ggb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/pwsX4d5W/width/425/height/373/border/888888/sri/true/sdz/false/" width="425px" height="373px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
           </pg-code>
           <statement>
             <p>
-              [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/pwsX4d5W/width/425/height/373/border/888888/sri/true/sdz/false/" width="425px" height="373px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+              <var name="$ggb" data="pgml"/>
             </p>
 
             <p>
@@ -1286,10 +1293,12 @@
             $formula=RadioButtons(
             ["\(2\log_2(x-4)\)","\(\frac{1}{2}\log_2(x-4)\)","\(\log_2(2x-4)\)","\(\log_2\left(\frac{x}{2}-4\right)\)"],2
             );
+            $ggb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/hkbdwXA3/width/425/height/373/border/888888/sri/true/sdz/false/" width="425px" height="373px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
+            $ggb2 = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/Pbu8g3NG/width/425/height/373/border/888888/sri/true/sdz/false/" width="425px" height="373px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
           </pg-code>
             <statement>
               <p>
-                [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/hkbdwXA3/width/425/height/373/border/888888/sri/true/sdz/false/" width="425px" height="373px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+                <var name="$ggb" data="pgml"/>
               </p>
 
               <p>
@@ -1301,7 +1310,7 @@
               </p>
 
               <p>
-                [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/Pbu8g3NG/width/425/height/373/border/888888/sri/true/sdz/false/" width="425px" height="373px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+                <var name="$ggb2" data="pgml"/>
               </p>
 
               <p>

--- a/src/activity-vertical-and-horizontal-translations.xml
+++ b/src/activity-vertical-and-horizontal-translations.xml
@@ -208,7 +208,7 @@
           <statement>
             <p>
               For each equation below, give a description of what we are changing
-              (<init>e.g.</init> <q>adding 10 to the outputs</q>).
+              (e.g.<nbsp/><q>adding 10 to the outputs</q>).
             </p>
 
             <p>

--- a/src/activity-vertical-and-horizontal-translations.xml
+++ b/src/activity-vertical-and-horizontal-translations.xml
@@ -484,6 +484,7 @@
                 $water=PopUp(
                 ["?","It increased slightly","It decreased slightly"],1
                 );
+                $ggb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/xSDE2bnJ/width/422/height/343/border/888888/smb/false/stb/false/stbh/false/ai/false/asb/false/sri/true/rc/false/ld/false/sdz/false/ctl/false" width="422px" height="343px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
             </pg-code>
           <statement>
             <p>
@@ -491,7 +492,7 @@
             </p>
 
             <p>
-              [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/xSDE2bnJ/width/422/height/343/border/888888/smb/false/stb/false/stbh/false/ai/false/asb/false/sri/true/rc/false/ld/false/sdz/false/ctl/false" width="422px" height="343px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+              <var name="$ggb" data="pgml"/>
             </p>
 
             <p>
@@ -877,6 +878,7 @@
                 $eqn=PopUp(
                 ["?","h = f(t + 2)","h = f(t - 2)"],"h = f(t - 2)"
                 );
+                $ggb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/RR2xR2aG/width/422/height/343/border/888888/smb/false/stb/false/stbh/false/ai/false/asb/false/sri/true/rc/false/ld/false/sdz/false/ctl/false" width="422px" height="343px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
             </pg-code>
           <statement>
             <p>
@@ -888,7 +890,7 @@
             </p>
 
             <p>
-              [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/RR2xR2aG/width/422/height/343/border/888888/smb/false/stb/false/stbh/false/ai/false/asb/false/sri/true/rc/false/ld/false/sdz/false/ctl/false" width="422px" height="343px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+              <var name="$ggb" data="pgml"/>
             </p>
 
             <p>
@@ -1150,10 +1152,11 @@
                     0, labels => ["y=f(x)-3=x^2-3","\(y=f(x)+3=x^2+3\)","None of these"],
                     displayLabels => 0
                 );
+                $ggb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/pXUT7wZS/width/431/height/313/border/888888/smb/false/stb/false/stbh/false/ai/false/asb/false/sri/true/rc/false/ld/false/sdz/false/ctl/false" width="431px" height="313px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
             </pg-code>
           <statement>
             <p>
-              [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/pXUT7wZS/width/431/height/313/border/888888/smb/false/stb/false/stbh/false/ai/false/asb/false/sri/true/rc/false/ld/false/sdz/false/ctl/false" width="431px" height="313px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+              <var name="$ggb" data="pgml"/>
             </p>
 
             <p>
@@ -1217,10 +1220,11 @@
                     1, labels => ["y=f(x+5)+3=(x+5)^2+3","y=f(x-5)+3=(x-5)^2+3","y=f(x-3)+5=(x-3)^2+5","y=f(x+3)-5=(x+3)^3+5","None of these"],
                     displayLabels => 0
                 );
+                $ggb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/qHkxbUVg/width/431/height/313/border/888888/rc/false/ai/false/sdz/false/smb/false/stb/false/stbh/true/ld/false/sri/false/at/auto" width="431px" height="313px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
             </pg-code>
           <statement>
             <p>
-              [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/qHkxbUVg/width/431/height/313/border/888888/rc/false/ai/false/sdz/false/smb/false/stb/false/stbh/true/ld/false/sri/false/at/auto" width="431px" height="313px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+              <var name="$ggb" data="pgml"/>
             </p>
 
             <p>

--- a/src/activity-vertical-stretches.xml
+++ b/src/activity-vertical-stretches.xml
@@ -218,10 +218,11 @@
           @a=map{($_-int($_)&lt;0.5)?int($_):int($_)+1}@f;
           @b=map{2*$_}@a;
           @c=map{0.5*$_}@a;
+          $ggb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/dAA6utJV/width/433/height/376/border/888888/sri/true/sdz/false/" width="433px" height="376px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
         </pg-code>
           <statement>
             <p>
-              [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/dAA6utJV/width/433/height/376/border/888888/sri/true/sdz/false/" width="433px" height="376px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+              <var name="$ggb" data="pgml"/>
             </p>
 
             <p>
@@ -297,6 +298,8 @@
           $didItGraph=PopUp(
           ["?","no","yes"],"yes"
           );
+          $ggb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/FNyrMUGq/width/433/height/406/border/888888/sri/true/sdz/false/" width="433px" height="406px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
+          $ggb2 = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/PFcvTbgD/width/433/height/406/border/888888/sri/true/sdz/false/" width="433px" height="406px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
         </pg-code>
           <stage>
           <statement>
@@ -307,7 +310,7 @@
             </p>
 
             <p>
-              [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/FNyrMUGq/width/433/height/406/border/888888/sri/true/sdz/false/" width="433px" height="406px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+              <var name="$ggb" data="pgml"/>
             </p>
 
             <p>
@@ -333,7 +336,7 @@
             </p>
 
             <p>
-              [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/PFcvTbgD/width/433/height/406/border/888888/sri/true/sdz/false/" width="433px" height="406px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+              <var name="$ggb2" data="pgml"/>
             </p>
 
             <p>
@@ -384,6 +387,7 @@
           $verticalCompression = PopUp(
           ["?","stretch it away from","compress it toward"],"compress it toward"
           );
+          $ggb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/aSr3RBYV/width/432/height/438/border/888888/sri/true/sdz/false/" width="432px" height="438px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
         </pg-code>
           <statement>
             <p>
@@ -391,7 +395,7 @@
             </p>
 
             <p>
-              [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/aSr3RBYV/width/432/height/438/border/888888/sri/true/sdz/false/" width="432px" height="438px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+              <var name="$ggb" data="pgml"/>
             </p>
 
             <p>
@@ -440,6 +444,7 @@
         <pg-code>
           $reflection=PopUp(["?","reflected over the x-axis","reflected over the y-axis"],"reflected over the x-axis");
           $stretch=PopUp(["?","vertically compressed by a factor of 1/2","vertically stretched by a factor of 2"],"vertically stretched by a factor of 2");
+          $ggb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/b2KYhMZS/width/433/height/518/border/888888/sri/true/sdz/false/" width="433px" height="518px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
         </pg-code>
           <statement>
             <p>
@@ -447,7 +452,7 @@
             </p>
 
             <p>
-              [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/b2KYhMZS/width/433/height/518/border/888888/sri/true/sdz/false/" width="433px" height="518px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+              <var name="$ggb" data="pgml"/>
             </p>
 
             <p>

--- a/src/chapter-combinations-of-functions.xml
+++ b/src/chapter-combinations-of-functions.xml
@@ -258,6 +258,7 @@
               $r2=40*$u2;
               $p1=$r1-$c1;
               $p2=$r2-$c2;
+              $ggb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/YsPBmPHE/width/434/height/440/border/888888/sri/true/sdz/false/" width="434px" height="440px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
             </pg-code>
           <statement>
             <p>
@@ -278,7 +279,7 @@
             </p>
 
             <p>
-              [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/YsPBmPHE/width/434/height/440/border/888888/sri/true/sdz/false/" width="434px" height="440px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+              <var name="$ggb" data="pgml"/>
             </p>
 
             <p>
@@ -556,6 +557,7 @@
         <webwork>
 
             <pg-code>
+              $ggb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/tAcMxrpj/width/411/height/410/border/888888/smb/false/stb/false/stbh/false/ai/false/asb/false/sri/true/rc/false/ld/false/sdz/false/ctl/false" width="411px" height="410px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
             </pg-code>
             <statement>
               <p>
@@ -568,7 +570,7 @@
               </p>
 
               <p>
-                [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/tAcMxrpj/width/411/height/410/border/888888/smb/false/stb/false/stbh/false/ai/false/asb/false/sri/true/rc/false/ld/false/sdz/false/ctl/false" width="411px" height="410px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+                <var name="$ggb" data="pgml"/>
               </p>
 
               <p>

--- a/src/chapter-combinations-of-functions.xml
+++ b/src/chapter-combinations-of-functions.xml
@@ -785,12 +785,12 @@
           </p>
 
           <p>
-            On a particular day between <m>6{:}00</m> P.M. and midnight,
+            On a particular day between <m>6{:}00</m> <pm/> and midnight,
             suppose the temperature outside is modeled by the function
             <me>
               T = g(h) = 24 - 3h
             </me>
-            where <m>h</m> is the number of hours after <m>6{:}00</m> P.M.
+            where <m>h</m> is the number of hours after <m>6{:}00</m> <pm/>.
           </p>
 
           <p>

--- a/src/chapter-combinations-of-functions.xml
+++ b/src/chapter-combinations-of-functions.xml
@@ -1069,13 +1069,8 @@
     </subsection>
 
     <exercises>
-      <exercisegroup>
-
-        <introduction>
-          <p>
-            Evaluating Combinations
-          </p>
-        </introduction>
+      <subexercises>
+        <title>Evaluating Combinations</title>
           <!-- Coded with PTX-incompatible structure. -->
           <!-- <exercise>
             <webwork source="Library/LoyolaChicago/Precalc/Chap2Sec1/Q30.pg" seed="1" />
@@ -1233,14 +1228,9 @@
           <webwork source="Library/CollegeOfIdaho/setAlgebra_02_02_AlgebraOfFunctions/22IntAlg_07_functOperation.pg" seed="1" />
         </exercise>
 
-      </exercisegroup>
-      <exercisegroup>
-
-        <introduction>
-          <p>
-            Formulas for Combinations
-          </p>
-        </introduction>
+      </subexercises>
+      <subexercises>
+        <title>Formulas for Combinations</title>
 
 <!-- The following problem does not use BEGIN_TEXT or BEGIN_PGML -->
 <!-- Not currently compatible with PTX (2/11/2019)               -->
@@ -1286,7 +1276,7 @@
           <webwork source="Library/LoyolaChicago/Precalc/Chap2Review/Q12.pg" seed="1" />
         </exercise>
 
-      </exercisegroup>
+      </subexercises>
     </exercises>
   </section>
 

--- a/src/chapter-composition-and-inverse.xml
+++ b/src/chapter-composition-and-inverse.xml
@@ -1023,10 +1023,11 @@
             <pg-code>
               $didItGraph=PopUp(["?","No","Yes"],2);
               $reflection=PopUp(["?","line y = x","x-axis","y-axis"],1);
+              $ggb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/ssqjr6pZ/width/425/height/373/border/888888/sdz/false/" width="425px" height="373px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
             </pg-code>
             <statement>
               <p>
-                [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/ssqjr6pZ/width/425/height/373/border/888888/sdz/false/" width="425px" height="373px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+                <var name="$ggb" data="pgml"/>
               </p>
 
               <p>
@@ -1463,10 +1464,11 @@
 
             <pg-code>
               $reason=PopUp(["?","A horizontal line would cross the graph of y=f(x) twice.","A vertical line would cross the graph of the inverse twice.","All of the above."],3);
+              $ggb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/fTMWxxhS/width/425/height/373/border/888888/sdz/false/" width="425px" height="373px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
             </pg-code>
             <statement>
               <p>
-                [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/fTMWxxhS/width/425/height/373/border/888888/sdz/false/" width="425px" height="373px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+                <var name="$ggb" data="pgml"/>
               </p>
 
               <p>
@@ -1612,10 +1614,11 @@
 
             <pg-code>
               $interval=PopUp(["?","x >= 0","x >= -2"],1);
+              $ggb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/jGC9Xk8r/width/425/height/373/border/888888/sdz/false/" width="425px" height="373px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
             </pg-code>
             <statement>
               <p>
-                [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/jGC9Xk8r/width/425/height/373/border/888888/sdz/false/" width="425px" height="373px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+                <var name="$ggb" data="pgml"/>
               </p>
 
               <p>

--- a/src/chapter-composition-and-inverse.xml
+++ b/src/chapter-composition-and-inverse.xml
@@ -2435,6 +2435,8 @@
 
 
     <exercises>
+      <subexercises>
+        <title>Evaluating Composite Functions</title>
 
       <exercise>
         <webwork>
@@ -2479,9 +2481,6 @@
             </statement>
         </webwork>
       </exercise>
-
-      <subexercises>
-        <title>Evaluating Composite Functions</title>
 
         <exercise>
           <webwork>

--- a/src/chapter-composition-and-inverse.xml
+++ b/src/chapter-composition-and-inverse.xml
@@ -1852,16 +1852,16 @@
                 <li>
                   <p>
                     From your experience, you know that if you leave at your usual
-                    time (<m>6{:}00</m> <init>a.m.</init>), the ride takes about <m>6</m>
+                    time (<m>6{:}00</m> <am/>), the ride takes about <m>6</m>
                     minutes. The ride time increases when you leave later in the
                     morning, taking about <m>12</m> minutes if you leave at
-                    <m>9{:}00</m> <init>a.m.</init>.
+                    <m>9{:}00</m> <am/>.
                   </p>
 
                   <p>
                     Let <m>L = g(T)</m> represent the length of time (in minutes)
                     the trip takes you, where the input <m>T</m> is the number of
-                    hours after <m>6{:}00</m> <init>a.m.</init>
+                    hours after <m>6{:}00</m> <am/>.
                   </p>
 
                   <p>

--- a/src/chapter-composition-and-inverse.xml
+++ b/src/chapter-composition-and-inverse.xml
@@ -2480,13 +2480,8 @@
         </webwork>
       </exercise>
 
-      <exercisegroup>
-
-        <introduction>
-          <p>
-            Evaluating Composite Functions
-          </p>
-        </introduction>
+      <subexercises>
+        <title>Evaluating Composite Functions</title>
 
         <exercise>
           <webwork>
@@ -2642,14 +2637,9 @@
           <webwork source="Library/org.sparta/Inverse_Functions/FR_inverse_prb1.pg" seed="1" />
         </exercise>
 
-      </exercisegroup>
-      <exercisegroup>
-
-        <introduction>
-          <p>
-            Formula of a Composite Function
-          </p>
-        </introduction>
+      </subexercises>
+      <subexercises>
+        <title>Formula of a Composite Function</title>
 
         <exercise>
           <webwork>
@@ -2778,14 +2768,9 @@
           <webwork source="Library/Utah/College_Algebra/set6_Polynomial_and_Rational_Functions/1050s6p14.pg" seed="1" />
         </exercise> -->
 
-      </exercisegroup>
-      <exercisegroup>
-
-        <introduction>
-          <p>
-            Graph of a Composite Function
-          </p>
-        </introduction>
+      </subexercises>
+      <subexercises>
+        <title>Graph of a Composite Function</title>
 
         <exercise>
           <webwork source="Library/LoyolaChicago/Precalc/Chap8Review/Q40.pg" seed="1" />
@@ -2795,14 +2780,9 @@
           <webwork source="Library/Union/setFunctionInverses/ur_inv_3.pg" seed="1" />
         </exercise>
 
-      </exercisegroup>
-      <exercisegroup>
-
-        <introduction>
-          <p>
-            Evaluating Inverse Functions
-          </p>
-        </introduction>
+      </subexercises>
+      <subexercises>
+        <title>Evaluating Inverse Functions</title>
 
 <!-- The following problem does not use BEGIN_TEXT or BEGIN_PGML -->
 <!-- Not currently compatible with PTX (2/11/2019)               -->
@@ -2841,14 +2821,9 @@
           <webwork source="Library/LoyolaChicago/Precalc/Chap8Sec1/Q02.pg" seed="1" />
         </exercise>
 
-      </exercisegroup>
-      <exercisegroup>
-
-        <introduction>
-          <p>
-            Formula of an Inverse Function
-          </p>
-        </introduction>
+      </subexercises>
+      <subexercises>
+        <title>Formula of an Inverse Function</title>
 
         <exercise>
           <webwork source="Library/LoyolaChicago/Precalc/Chap2Sec4/Connally3-2-4-28-Composition-inverse.pg" seed="1" />
@@ -2898,14 +2873,9 @@
           <webwork source="Library/UMN/calculusStewartCCC/s_1_6_26.pg" seed="1" />
         </exercise>
 
-      </exercisegroup>
-      <exercisegroup>
-
-        <introduction>
-          <p>
-            Graph of an Inverse Function
-          </p>
-        </introduction>
+      </subexercises>
+      <subexercises>
+        <title>Graph of an Inverse Function</title>
 
         <exercise>
           <webwork source="Library/UCSB/Stewart5_1_6/Stewart5_1_6_2.pg" seed="1" />
@@ -2937,14 +2907,9 @@
           <webwork source="Library/Rochester/setAlgebra18FunInverse/srw2_10_17a.pg" seed="1" />
         </exercise> -->
 
-      </exercisegroup>
-      <exercisegroup>
-
-        <introduction>
-          <p>
-            Restricting the Domain
-          </p>
-        </introduction>
+      </subexercises>
+      <subexercises>
+        <title>Restricting the Domain</title>
 
         <exercise>
           <webwork>
@@ -3011,14 +2976,9 @@
           </webwork>
         </exercise>
 
-      </exercisegroup>
-      <exercisegroup>
-
-        <introduction>
-          <p>
-            Additional Problems
-          </p>
-        </introduction>
+      </subexercises>
+      <subexercises>
+        <title>Additional Problems</title>
 
         <exercise>
           <webwork>
@@ -3294,14 +3254,9 @@
           <webwork source="Library/LoyolaChicago/Precalc/Chap8Review/Q49.pg" seed="1" />
         </exercise>
 
-      </exercisegroup>
-      <exercisegroup>
-
-        <introduction>
-          <p>
-            Written Homework
-          </p>
-        </introduction>
+      </subexercises>
+      <subexercises>
+        <title>Written Homework</title>
 
         <exercise>
           <statement>
@@ -3365,7 +3320,7 @@
           </statement>
         </exercise>
 
-      </exercisegroup>
+      </subexercises>
     </exercises>
   </section>
 </chapter>

--- a/src/chapter-domain-and-range-piecewise.xml
+++ b/src/chapter-domain-and-range-piecewise.xml
@@ -336,11 +336,13 @@
               $dom1 = Compute("2&lt;=x&lt;6");
               $rng1 = Compute("1.5&lt;=y&lt;3.5");
               $rng2 = Compute("3&lt;=y&lt;5");
+              $ggb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/s4F4ptNM/width/413/height/370/border/888888" width="413px" height="370px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
+              $ggb2 = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/s4F4ptNM/width/413/height/370/border/888888" width="413px" height="370px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
             </pg-code>
             <stage>
             <statement>
               <p>
-                [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/s4F4ptNM/width/413/height/370/border/888888" width="413px" height="370px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+                <var name="$ggb" data="pgml"/>
               </p>
 
               <p>
@@ -369,7 +371,7 @@
             <stage>
             <statement>
               <p>
-                [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/s4F4ptNM/width/413/height/370/border/888888" width="413px" height="370px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+                <var name="$ggb2" data="pgml"/>
               </p>
 
               <p>
@@ -530,10 +532,11 @@
                 Context("Inequalities");
                 $answer1 = Compute("-5&lt;=x&lt;0");
                 $answer2 = Compute("1&lt;=x&lt;=4");
+                $ggb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/tVFj33nG/width/431/height/313/border/888888/sri/true" width="431px" height="313px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
             </pg-code>
             <statement>
               <p>
-                [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/tVFj33nG/width/431/height/313/border/888888/sri/true" width="431px" height="313px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+                <var name="$ggb" data="pgml"/>
               </p>
 
               <p>
@@ -581,10 +584,11 @@
               ["Function A","Function B","Function C"],
               2, labels => ["Function A","Function B","Function C"],displayLabels => 0
               );
+              $ggb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/UY2xPaVW/width/413/height/300/border/888888" width="413px" height="300px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
             </pg-code>
             <statement>
               <p>
-                [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/UY2xPaVW/width/413/height/300/border/888888" width="413px" height="300px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+                <var name="$ggb" data="pgml"/>
               </p>
 
               <p>

--- a/src/chapter-domain-and-range-piecewise.xml
+++ b/src/chapter-domain-and-range-piecewise.xml
@@ -1495,13 +1495,8 @@
     </subsection>
 
     <exercises>
-      <exercisegroup>
-
-        <introduction>
-          <p>
-            Domain and Range
-          </p>
-        </introduction>
+      <subexercises>
+        <title>Domain and Range</title>
 
         <exercise>
           <webwork source="Library/Mizzou/Algebra/functions_domain_range/fun_dom_15.pg" seed="1" />
@@ -1531,14 +1526,9 @@
           <webwork source="Library/LoyolaChicago/Precalc/Chap2Sec2/Q23.pg" seed="1" />
         </exercise>
 
-      </exercisegroup>
-      <exercisegroup>
-
-        <introduction>
-          <p>
-            Evaluating Piecewise Functions
-          </p>
-        </introduction>
+      </subexercises>
+      <subexercises>
+        <title>Evaluating Piecewise Functions</title>
 
         <exercise>
           <webwork>
@@ -1832,14 +1822,9 @@
           <webwork source="Library/Mizzou/Algebra/functions_piecewise/evaluate_at_a_point_03.pg" seed="1" />
         </exercise>
 
-      </exercisegroup>
-      <exercisegroup>
-
-        <introduction>
-          <p>
-            Formulas for Piecewise Functions
-          </p>
-        </introduction>
+      </subexercises>
+      <subexercises>
+        <title>Formulas for Piecewise Functions</title>
 
         <exercise>
           <webwork source="Library/LoyolaChicago/Precalc/Chap2Sec3/Connally3-2-3-02-Piecewise-functions.pg" seed="1" />
@@ -1853,16 +1838,11 @@
           <webwork source="Library/Mizzou/Algebra/functions_piecewise/mc_determine_graph_01.pg" seed="1" />
         </exercise>
 
-      </exercisegroup>
-      <!-- <exercisegroup>
+      </subexercises>
+      <!-- <subexercises>
+      <title>Additional Problems</title>
 
-        <introduction>
-          <p>
-            Additional Problems
-          </p>
-        </introduction>
-
-      </exercisegroup> -->
+      </subexercises> -->
     </exercises>
   </section>
 </chapter>

--- a/src/chapter-domain-and-range-piecewise.xml
+++ b/src/chapter-domain-and-range-piecewise.xml
@@ -1137,7 +1137,7 @@
               </p>
 
               <p>
-                If you rented the washer at <m>9{:}15</m> a.m. and returned it at <m>3{:}45</m> on the same day,
+                If you rented the washer at <m>9{:}15</m> <am/> and returned it at <m>3{:}45</m> on the same day,
                 what would you owe?
               </p>
 
@@ -1557,7 +1557,7 @@
                 </p>
 
                 <p>
-                  If you rented the washer at <m>9{:}15</m> a.m. and returned it at <m>3{:}45</m> on the same day,
+                  If you rented the washer at <m>9{:}15</m> <am/> and returned it at <m>3{:}45</m> on the same day,
                   what would you owe?
                 </p>
 

--- a/src/chapter-exponential-functions.xml
+++ b/src/chapter-exponential-functions.xml
@@ -588,9 +588,12 @@
 
       <exercise>
         <webwork>
+          <pg-code>
+            $ggb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/maBU9N6E/width/431/height/390/border/888888/smb/false/stb/false/stbh/false/ai/false/asb/false/sri/false/rc/false/ld/false/sdz/false/ctl/false" width="431px" height="390px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
+          </pg-code>
             <statement>
               <p>
-                [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/maBU9N6E/width/431/height/390/border/888888/smb/false/stb/false/stbh/false/ai/false/asb/false/sri/false/rc/false/ld/false/sdz/false/ctl/false" width="431px" height="390px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+                <var name="$ggb" data="pgml"/>
               </p>
 
               <p>

--- a/src/chapter-exponential-functions.xml
+++ b/src/chapter-exponential-functions.xml
@@ -1840,13 +1840,8 @@
     </subsection> -->
     <exercises>
 <!-- find the exponential formula -->
-      <exercisegroup>
-
-        <introduction>
-          <p>
-            Formulas for Exponential Functions
-          </p>
-        </introduction>
+      <subexercises>
+        <title>Formulas for Exponential Functions</title>
 
         <exercise>
           <webwork source="Library/LoyolaChicago/Precalc/Chap9Sec7/Q03.pg" seed="1" />
@@ -1872,15 +1867,10 @@
           <webwork source="Library/LoyolaChicago/Precalc/Chap3Sec2/Q22.pg" seed="1" />
         </exercise>
 
-      </exercisegroup>
+      </subexercises>
 <!-- evaluate an exponential function -->
-      <exercisegroup>
-
-        <introduction>
-          <p>
-            Evaluating Exponential Functions
-          </p>
-        </introduction>
+      <subexercises>
+        <title>Evaluating Exponential Functions</title>
 
         <exercise>
           <webwork source="Library/Rochester/setAlgebra28ExpFunctions/sw6_1_3.pg" seed="1" />
@@ -1890,15 +1880,10 @@
           <webwork source="Library/Michigan/Chap1Sec2/Q38.pg" seed="1" />
         </exercise>
 
-      </exercisegroup>
+      </subexercises>
 <!-- Name the parts of an exponential formula -->
-      <exercisegroup>
-
-        <introduction>
-          <p>
-            Building a Formula
-          </p>
-        </introduction>
+      <subexercises>
+        <title>Building a Formula</title>
 
         <exercise>
           <webwork source="Library/LoyolaChicago/Precalc/Chap4Sec2/Q14V2.pg" seed="1" />
@@ -1912,16 +1897,10 @@
           <webwork source="Library/LoyolaChicago/Precalc/Chap3Sec1/Connally3-3-1-12-Exponential-functions.pg" seed="1" />
         </exercise>
 
-      </exercisegroup>
+      </subexercises>
 <!-- Linear vs Exponential -->
-      <exercisegroup>
-
-        <introduction>
-          <p>
-            Exponential vs.
-            Linear
-          </p>
-        </introduction>
+      <subexercises>
+        <title>Exponential vs.<nbsp/>Linear</title>
 
         <exercise>
           <webwork source="Library/LoyolaChicago/Precalc/Chap3Sec2/Q01.pg" seed="1" />
@@ -1935,15 +1914,10 @@
           <webwork source="Library/LoyolaChicago/Precalc/Chap3Sec2/Connally3-3-2-05-Exponential-vs-linear.pg" seed="1" />
         </exercise>
 
-      </exercisegroup>
+      </subexercises>
 <!-- end behavior and graphs -->
-      <exercisegroup>
-
-        <introduction>
-          <p>
-            Additional Problems
-          </p>
-        </introduction>
+      <subexercises>
+        <title>Additional Problems</title>
 
         <exercise>
           <webwork source="Library/UCSB/Stewart5_1_5/Stewart5_1_5_3.pg" seed="1" />
@@ -2130,7 +2104,7 @@
           </webwork>
         </exercise>
 
-      </exercisegroup>
+      </subexercises>
     </exercises>
   </section>
 

--- a/src/chapter-exponential-functions.xml
+++ b/src/chapter-exponential-functions.xml
@@ -440,7 +440,7 @@
         In the <xref ref="linear-data">linear table</xref>
         we are adding <m>1.25</m> to the output every <m>5</m> units of input.
         In the <xref ref="exponential-data">exponential table</xref>
-        we are multiplying the output by <m>1.25</m> (<init>i.e.</init> a <m>25 \%</m> increase) for every <m>5</m> units of input.
+        we are multiplying the output by <m>1.25</m> (i.e.<nbsp/>a <m>25 \%</m> increase) for every <m>5</m> units of input.
       </p>
 
       <example>
@@ -754,7 +754,7 @@
         <p>
           In this example <m>a=500</m> is the initial size of the population
           when the measuring began and <m>b \approx 1.007726</m> is the annual
-          growth factor (<init>i.e.</init> the number that is multiplied repeatedly)
+          growth factor (i.e.<nbsp/>the number that is multiplied repeatedly)
           representing an annual percent growth of about <m>0.7726 \%</m> each year.
         </p>
       </example>
@@ -1812,8 +1812,8 @@
       <title>Examples</title>
       <example>
       <title>The Biologist</title>
-        <p>A biologist measures the amount of chemical spilled into a lake 6 hours after the spill has occurred to be about 350 <initial>ppm</initial> (parts per million).</p>
-        <p>She tests the water from the lake again 8 hours later and measures the chemical to be about 256 <initial>ppm</initial></p>
+        <p>A biologist measures the amount of chemical spilled into a lake 6 hours after the spill has occurred to be about 350 ppm (parts per million).</p>
+        <p>She tests the water from the lake again 8 hours later and measures the chemical to be about 256 ppm.</p>
         <p>Assuming a linear model, L(t), what is the average rate of change of the decay of the chemical in the lake?</p>
         <p>Assuming an exponential model, E(t), what is the hourly percent decrease of the chemical in the lake?</p>
         <p>What does each model predict as the initial size of the spill?</p>

--- a/src/chapter-functions.xml
+++ b/src/chapter-functions.xml
@@ -545,10 +545,11 @@
 
             <pg-code>
                 $f35 = Real(36.5);
+                $ggb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/KuW5Vbqz/width/413/height/331/border/888888" width="413px" height="331px" style="border:0px;" width="431px" height="313px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
             </pg-code>
             <statement>
               <p>
-                [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/KuW5Vbqz/width/413/height/331/border/888888" width="413px" height="331px" style="border:0px;" width="431px" height="313px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+                <var name="$ggb" data="pgml"/>
               </p>
 
               <p>
@@ -589,10 +590,11 @@
             <pg-code>
                 $sol1 = Real(45.2);
                 $sol2 = Real(70.4);
+                $ggb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/shNZ7dsh/width/413/height/331/border/888888" width="413px" height="331px" style="border:0px;" width="431px" height="313px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
             </pg-code>
             <statement>
               <p>
-                [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/shNZ7dsh/width/413/height/331/border/888888" width="413px" height="331px" style="border:0px;" width="431px" height="313px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+                <var name="$ggb" data="pgml"/>
               </p>
 
               <p>
@@ -664,10 +666,11 @@
             <pg-code>
                 $avrt1 = Real(1.1);
                 $avrt2 = Real(-0.8);
+                $ggb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/dGpvT5eC/width/413/height/331/border/888888" width="413px" height="331px" style="border:0px;" width="431px" height="313px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
             </pg-code>
             <statement>
               <p>
-                [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/dGpvT5eC/width/413/height/331/border/888888" width="413px" height="331px" style="border:0px;" width="431px" height="313px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+                <var name="$ggb" data="pgml"/>
               </p>
 
               <p>

--- a/src/chapter-functions.xml
+++ b/src/chapter-functions.xml
@@ -1641,7 +1641,7 @@
 <!--
         <exercises>
 
-        <exercisegroup><introduction><p>Interpretating Function Notation</p></introduction>
+        <subexercises><title>Interpretating Function Notation</title>
 
           <exercise>
             <webwork>
@@ -1692,9 +1692,9 @@
             </webwork>
           </exercise>
 
-        </exercisegroup>
+        </subexercises>
 
-        <exercisegroup><introduction><p>Evaluating Functions</p></introduction>
+        <subexercises><title>Evaluating Functions</title>
           <exercise>
             <webwork source="Library/Utah/Intermediate_Algebra/set5_Graphs_and_Functions/s5p32.pg" seed="1" />
           </exercise>
@@ -1730,9 +1730,9 @@
           <exercise>
             <webwork source="Library/PCC/BasicAlgebra/FunctionBasics/EvaluateFunction70.pg" seed="1" />
           </exercise>
-        </exercisegroup>
+        </subexercises>
 
-<exercisegroup><introduction><p>Evaluating and Making Combinations</p></introduction>
+<subexercises><title>Evaluating and Making Combinations</title>
           <exercise>
             <webwork source="Library/LoyolaChicago/Precalc/Chap2Sec1/Connally3-2-1-24-Input-and-output.pg" seed="1" />
           </exercise>
@@ -1748,9 +1748,9 @@
           <exercise>
             <webwork source="Library/UVA-Stew5e/setUVA-Stew5e-C01S03-NewFunctOld/1-3-31.pg" seed="1" />
           </exercise>
-</exercisegroup>
+</subexercises>
 
-<exercisegroup><introduction><p>Function Graphs</p></introduction>
+<subexercises><title>Function Graphs</title>
           <exercise>
             <webwork source="Library/PCC/BasicAlgebra/FunctionBasics/Functions120.pg" seed="1" />
           </exercise>
@@ -1770,9 +1770,9 @@
           <exercise>
             <webwork source="Library/Westmont/ActiveCalculus/Preview_1_3/preview_1_3_a/preview_1_3_a.pg" seed="1" />
           </exercise>
-</exercisegroup>
+</subexercises>
 
-<exercisegroup><introduction><p>Average Rate of Change and Difference Quotient</p></introduction>
+<subexercises><title>Average Rate of Change and Difference Quotient</title>
 
           <exercise>
             <webwork>
@@ -1942,9 +1942,9 @@
           <exercise>
             <webwork source="Library/LoyolaChicago/Precalc/Chap1Sec2/Q16.pg" seed="1" />
           </exercise>
-</exercisegroup>
+</subexercises>
 
-<exercisegroup><introduction><p>Evaluating Functions and Solving for an Unknown</p></introduction>
+<subexercises><title>Evaluating Functions and Solving for an Unknown</title>
           <exercise>
             <webwork source="Library/LoyolaChicago/Precalc/Chap2Sec1/Connally3-2-1-09-Input-and-output.pg" seed="1" />
           </exercise>
@@ -1964,9 +1964,9 @@
           <exercise>
             <webwork source="Library/PCC/BasicAlgebra/FunctionBasics/FunctionValuesByGraph30.pg" seed="1" />
           </exercise>
-</exercisegroup>
+</subexercises>
 
-<exercisegroup><introduction><p>Identifying a Function</p></introduction>
+<subexercises><title>Identifying a Function</title>
           <exercise>
             <webwork source="Library/Wiley/setAnton_Section_0.1/Question3.pg" seed="1" />
           </exercise>
@@ -1986,19 +1986,19 @@
           <exercise>
             <webwork source="Library/PCC/BasicAlgebra/FunctionBasics/FunctionOrNotByGraph10.pg" seed="1" />
           </exercise>
-</exercisegroup>
+</subexercises>
 
-<exercisegroup><introduction><p>Additional Problems</p></introduction>
+<subexercises><title>Additional Problems</title>
 
           <exercise>
             <webwork source="Library/ASU-topics/setFunctions/rich1.pg" seed="1" />
           </exercise>
 
-</exercisegroup>
+</subexercises>
 
 <<<<<<< Updated upstream
 
-<exercisegroup><introduction><p>Additional Problems</p></introduction>
+<subexercises><title>Additional Problems</title>
   <exercise>
     <statement>
       <p>Define the following variables:</p>
@@ -2016,7 +2016,7 @@
     </statement>
   </exercise>
 
-</exercisegroup>
+</subexercises>
 
         </exercises>
 -->

--- a/src/chapter-logarithmic-functions.xml
+++ b/src/chapter-logarithmic-functions.xml
@@ -386,9 +386,12 @@
         </introduction>
 
         <webwork>
+          <pg-name>
+            $ggb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/Z4mRThfg/width/431/height/455/border/888888/smb/false/stb/false/stbh/false/ai/false/asb/false/sri/false/rc/false/ld/false/sdz/false/ctl/false" width="431px" height="455px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
+          </pg-name>
             <statement>
               <p>
-                [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/Z4mRThfg/width/431/height/455/border/888888/smb/false/stb/false/stbh/false/ai/false/asb/false/sri/false/rc/false/ld/false/sdz/false/ctl/false" width="431px" height="455px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+                <var name="$ggb" data="pgml"/>
               </p>
 
               <p>
@@ -1241,6 +1244,7 @@
                 Context()->variables->set(P=>{limits=>[0.01,0.99]});
                 $step=Compute("ln(P/(1-P))");
                 $solution=Compute("e^t/(1+e^t)");
+                $ggb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/Bg52rewM/width/431/height/435/border/888888/smb/false/stb/false/stbh/false/ai/false/asb/false/sri/false/rc/false/ld/false/sdz/false/ctl/false" width="431px" height="435px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
             </pg-code>
             <stage>
             <statement>
@@ -1321,7 +1325,7 @@
             <stage>
             <statement>
               <p>
-                [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/Bg52rewM/width/431/height/435/border/888888/smb/false/stb/false/stbh/false/ai/false/asb/false/sri/false/rc/false/ld/false/sdz/false/ctl/false" width="431px" height="435px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+                <var name="$ggb" data="pgml"/>
               </p>
 
               <p>

--- a/src/chapter-logarithmic-functions.xml
+++ b/src/chapter-logarithmic-functions.xml
@@ -2000,13 +2000,8 @@
 
     <exercises>
 <!-- rewriting logs as exponents -->
-      <exercisegroup>
-
-        <introduction>
-          <p>
-            Definition of the Logarithm
-          </p>
-        </introduction>
+      <subexercises>
+      <title>Definition of the Logarithm</title>
 
         <exercise>
           <webwork source="Library/LoyolaChicago/Precalc/Chap4Sec1/Q04.pg" seed="1" />
@@ -2024,15 +2019,10 @@
           <webwork source="Library/LoyolaChicago/Precalc/Chap4Sec1/Q08.pg" seed="1" />
         </exercise>
 
-      </exercisegroup>
+      </subexercises>
 <!-- solving exponential equations basic -->
-      <exercisegroup>
-
-        <introduction>
-          <p>
-            Solving Exponential Equations with Logarithms
-          </p>
-        </introduction>
+      <subexercises>
+        <title>Solving Exponential Equations with Logarithms</title>
 
         <exercise>
           <webwork source="Library/Union/setFunctionExponential/srw4_1_11.pg" seed="1" />
@@ -2080,15 +2070,10 @@
           <webwork source="Library/maCalcDB/setAlgebra30LogExpEqns/solve_in_exponent.pg" seed="1" />
         </exercise>-->
 
-      </exercisegroup>
+      </subexercises>
 <!-- solving basic logarithmic equations -->
-      <exercisegroup>
-
-        <introduction>
-          <p>
-            Solving Logarithmic Equations
-          </p>
-        </introduction>
+      <subexercises>
+        <title>Solving Logarithmic Equations</title>
 
 <!-- The following problem does not use BEGIN_TEXT or BEGIN_PGML -->
 <!-- Not currently compatible with PTX (2/11/2019)               -->
@@ -2140,15 +2125,10 @@
           <webwork source="Library/WHFreeman/Rogawski_Calculus_Early_Transcendentals_Second_Edition/1_Precalculus_Review/1.6_Exponential_and_Logarithmic_Functions/1.6.33.pg" seed="1" />
         </exercise>
 
-      </exercisegroup>
+      </subexercises>
 <!-- harder equations -->
-      <exercisegroup>
-
-        <introduction>
-          <p>
-            Additional Problems
-          </p>
-        </introduction>
+      <subexercises>
+        <title>Additional Problems</title>
 
         <exercise>
           <webwork source="Library/UCSB/Stewart5_1_6/Stewart5_1_6_52.pg" seed="1" />
@@ -2184,14 +2164,9 @@
           <webwork source="Library/ASU-topics/setLogarithmicFunctions/jj7.pg" seed="1" />
         </exercise>
 
-      </exercisegroup>
-      <exercisegroup>
-
-        <introduction>
-          <p>
-            Applications
-          </p>
-        </introduction>
+      </subexercises>
+      <subexercises>
+        <title>Applications</title>
 
         <exercise>
           <webwork>
@@ -3007,7 +2982,7 @@
           </webwork>
         </exercise>
 
-      </exercisegroup>
+      </subexercises>
     </exercises>
   </section>
 

--- a/src/chapter-power-functions-and-polynomials.xml
+++ b/src/chapter-power-functions-and-polynomials.xml
@@ -827,6 +827,7 @@
                 2, labels => ["(x+1)(x-1)(x-3)","(x+1)^2(x-1)(x-3)","(x+1)^2(x-1)(x-3)^2","(x+1)^2(x-1)^2(x-3)^2","None of these"],
                 displayLabels => 0
               );
+              $ggb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/qUku8jCM/width/425/height/373/border/888888/sdz/false/" width="425px" height="373px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
             </pg-code>
             <statement>
               <p>
@@ -834,7 +835,7 @@
               </p>
 
               <p>
-                [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/qUku8jCM/width/425/height/373/border/888888/sdz/false/" width="425px" height="373px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+                <var name="$ggb" data="pgml"/>
               </p>
 
               <p>
@@ -1017,6 +1018,7 @@
         <webwork>
 
             <pg-code>
+              $ggb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/MRSRj24k/width/425/height/373/border/888888/smb/false/stb/false/stbh/false/ai/false/asb/false/sri/false/rc/false/ld/false/sdz/false/ctl/false" width="425px" height="373px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
             </pg-code>
             <statement>
               <p>
@@ -1047,7 +1049,7 @@
               </p>
 
               <p>
-                [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/MRSRj24k/width/425/height/373/border/888888/smb/false/stb/false/stbh/false/ai/false/asb/false/sri/false/rc/false/ld/false/sdz/false/ctl/false" width="425px" height="373px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+                <var name="$ggb" data="pgml"/>
               </p>
             </statement>
         </webwork>

--- a/src/chapter-power-functions-and-polynomials.xml
+++ b/src/chapter-power-functions-and-polynomials.xml
@@ -1156,13 +1156,8 @@
     </subsection>
 
     <exercises>
-      <exercisegroup>
-
-        <introduction>
-          <p>
-            Graphs of Power Functions and Polynomials
-          </p>
-        </introduction>
+      <subexercises>
+        <title>Graphs of Power Functions and Polynomials</title>
         <!-- Coded with PTX-incompatible structure. -->
         <!-- <exercise>
           <webwork source="Library/UMN/algebraKaufmannSchwitters/ks_8_5_3.pg" seed="1" />
@@ -1208,15 +1203,10 @@
         <!-- <exercise>
           <webwork source="Library/LoyolaChicago/Precalc/Chap9Sec2/polynomial-04.pg" seed="1" />
         </exercise> -->
-      </exercisegroup>
+      </subexercises>
 <!-- zeros and multiplicities -->
-      <exercisegroup>
-
-        <introduction>
-          <p>
-            Degree, Roots, Multiplicities and End Behavior
-          </p>
-        </introduction>
+      <subexercises>
+        <title>Degree, Roots, Multiplicities and End Behavior</title>
 
         <exercise>
           <webwork source="Library/Mizzou/College_Algebra/Polynomials_Zeroes_Multiplicities/Mult1.pg" seed="1" />
@@ -1264,15 +1254,10 @@
           <webwork source="Library/LoyolaChicago/Precalc/Chap9Sec2/polynomial-03.pg" seed="1" />
         </exercise>
 
-      </exercisegroup>
+      </subexercises>
 <!-- Algebraic simplification -->
-      <exercisegroup>
-
-        <introduction>
-          <p>
-            Algebraic Simplification
-          </p>
-        </introduction>
+      <subexercises>
+        <title>Algebraic Simplification</title>
 
         <exercise>
           <webwork source="Library/FortLewis/Algebra/4-2-Functions-and-expressions/MCH1-4-2-14-Functions-and-expressions.pg" seed="1" />
@@ -1284,15 +1269,10 @@
           <webwork source="Library/Utah/Intermediate_Algebra/set9_Polynomials_and_Factoring/s9p17.pg" seed="1" />
         </exercise> -->
 
-      </exercisegroup>
+      </subexercises>
 <!-- Find the equation of the polynomial -->
-      <exercisegroup>
-
-        <introduction>
-          <p>
-            Formulas for Polynomials
-          </p>
-        </introduction>
+      <subexercises>
+        <title>Formulas for Polynomials</title>
 
         <exercise>
           <webwork source="Library/ASU-topics/setPolynomialFunctions/rich4.pg" seed="1" />
@@ -1344,15 +1324,10 @@
           <webwork source="Library/UMN/algebraKaufmannSchwitters/ks_9_4_prob07.pg" seed="1" />
         </exercise>
 
-      </exercisegroup>
+      </subexercises>
 <!-- choose the correct graph -->
-      <exercisegroup>
-
-        <introduction>
-          <p>
-            Graphs of Polynomials
-          </p>
-        </introduction>
+      <subexercises>
+        <title>Graphs of Polynomials</title>
 
         <exercise>
           <webwork source="Library/Mizzou/College_Algebra/Graphing_Polynomials/MC_Find_Graph_Not_Factored_Random_Deg_3_4.pg" seed="1" />
@@ -1365,15 +1340,10 @@
         <!-- <exercise>
           <webwork source="Library/UMN/algebraKaufmannSchwitters/ks_9_4_prob02.pg" seed="1" />
         </exercise> -->
-      </exercisegroup>
+      </subexercises>
 <!-- application problems -->
-      <!-- <exercisegroup>
-
-        <introduction>
-          <p>
-            Additional Problems
-          </p>
-        </introduction> -->
+      <!-- <subexercises>
+      <title>Additional Problems</title> -->
 
 <!-- The following problem does not use BEGIN_TEXT or BEGIN_PGML -->
 <!-- Not currently compatible with PTX (2/11/2019)               -->
@@ -1381,7 +1351,7 @@
           <webwork source="Library/Rochester/setAlgebra23PolynomialZeros/beth1polydiv.pg" seed="1" />
         </exercise> -->
 
-      <!-- </exercisegroup> -->
+      <!-- </subexercises> -->
     </exercises>
   </section>
 

--- a/src/chapter-reflections-and-vertical-stretches.xml
+++ b/src/chapter-reflections-and-vertical-stretches.xml
@@ -1314,13 +1314,8 @@
     </subsection>
 
     <exercises>
-      <exercisegroup>
-
-        <introduction>
-          <p>
-            Interpreting Transformations
-          </p>
-        </introduction>
+      <subexercises>
+        <title>Interpreting Transformations</title>
 
         <exercise>
           <webwork source="Library/LoyolaChicago/Precalc/Chap5Review/Q34.pg" seed="1" />
@@ -1330,14 +1325,9 @@
           <webwork source="Library/LoyolaChicago/Precalc/Chap5Sec4/Q18.pg" seed="1" />
         </exercise>
 
-      </exercisegroup>
-      <exercisegroup>
-
-        <introduction>
-          <p>
-            Even and Odd
-          </p>
-        </introduction>
+      </subexercises>
+      <subexercises>
+        <title>Even and Odd</title>
 
         <exercise>
           <webwork source="Library/LoyolaChicago/Precalc/Chap5Review/Q10.pg" seed="1" />
@@ -1381,14 +1371,9 @@
           <webwork source="Library/Utah/AP_Calculus_I/set1_Reviews_of_Fundamentals/1210s2p5.pg" seed="1" />
         </exercise>-->
 
-      </exercisegroup>
-      <exercisegroup>
-
-        <introduction>
-          <p>
-            Graphs of Reflections and Stretches
-          </p>
-        </introduction>
+      </subexercises>
+      <subexercises>
+        <title>Graphs of Reflections and Stretches</title>
 
         <exercise>
           <webwork source="Library/LoyolaChicago/Precalc/Chap5Review/Q18.pg" seed="1" />
@@ -1398,14 +1383,9 @@
           <webwork source="Library/ASU-topics/setTransformationFunctions/jj1.pg" seed="1" />
         </exercise>
 
-      </exercisegroup>
-      <exercisegroup>
-
-        <introduction>
-          <p>
-            Formula of a Reflection or Vertical Stretch
-          </p>
-        </introduction>
+      </subexercises>
+      <subexercises>
+        <title>Formula of a Reflection or Vertical Stretch</title>
 
         <exercise>
           <webwork source="Library/LoyolaChicago/Precalc/Chap5Review/Q20.pg" seed="1" />
@@ -1449,14 +1429,9 @@
           <webwork source="Library/ASU-topics/setLogarithmicFunctions/ur_le_2_13.pg" seed="1" />
         </exercise> -->
 
-      </exercisegroup>
-      <exercisegroup>
-
-        <introduction>
-          <p>
-            Geometry of Reflections and Vertical Stretches
-          </p>
-        </introduction>
+      </subexercises>
+      <subexercises>
+        <title>Geometry of Reflections and Vertical Stretches</title>
 
         <exercise>
           <webwork source="Library/LoyolaChicago/Precalc/Chap5Review/Q04.pg" seed="1" />
@@ -1478,14 +1453,9 @@
           <webwork source="Library/LoyolaChicago/Precalc/Chap5Sec2/Q02.pg" seed="1" />
         </exercise>
 
-      </exercisegroup>
-      <exercisegroup>
-
-        <introduction>
-          <p>
-            Additional Problems
-          </p>
-        </introduction>
+      </subexercises>
+      <subexercises>
+        <title>Additional Problems</title>
 
         <exercise>
           <webwork source="Library/UCSB/Stewart5_1_6/Stewart5_1_6_61.pg" seed="1" />
@@ -1511,14 +1481,9 @@
           <webwork source="Library/ASU-topics/setExponentialFunctions/srw4_1_29.pg" seed="1" />
         </exercise>
 
-      </exercisegroup>
-      <exercisegroup>
-
-        <introduction>
-          <p>
-            Horizontal Stretches
-          </p>
-        </introduction>
+      </subexercises>
+      <subexercises>
+        <title>Horizontal Stretches</title>
 
         <exercise>
           <webwork source="Library/UVA-Stew5e/setUVA-Stew5e-C01S03-NewFunctOld/1-3-06.pg" seed="1" />
@@ -1544,7 +1509,7 @@
           <webwork source="Library/LoyolaChicago/Precalc/Chap5Sec4/Q16.pg" seed="1" />
         </exercise>
 
-      </exercisegroup>
+      </subexercises>
     </exercises>
   </section>
 </chapter>

--- a/src/chapter-vertical-and-horizontal-translations.xml
+++ b/src/chapter-vertical-and-horizontal-translations.xml
@@ -723,21 +723,21 @@
             </p>
 
             <p>
-              At 9:00 a.m., a cup of tea was heated to <m>200</m> degrees Fahrenheit and then left to sit in a <m>70</m> degree kitchen.
+              At 9:00 <am/>, a cup of tea was heated to <m>200</m> degrees Fahrenheit and then left to sit in a <m>70</m> degree kitchen.
             </p>
 
             <p>
               The graph of <m>T = f(t)</m> shows the temperature
               (in degrees Fahrenheit)
               of the cup of tea as it cooled down toward room temperature,
-              where <m>t</m> is the number of minutes after 9:00 a.m.
+              where <m>t</m> is the number of minutes after 9:00 <am/>.
             </p>
 
             <p>
               By moving the slider,
               you can change the time at which the tea stopped heating and began to cool.
               For instance,
-              if it began to cool at 9:20 a.m., then the graph would be exactly the same <mdash /> just shifted to the
+              if it began to cool at 9:20 <am/>, then the graph would be exactly the same <mdash /> just shifted to the
               <em>right</em> by <m>20</m> minutes.
             </p>
 

--- a/src/chapter-vertical-and-horizontal-translations.xml
+++ b/src/chapter-vertical-and-horizontal-translations.xml
@@ -167,10 +167,11 @@
             <pg-code>
                 $neg=PopUp(["?","positive","negative"],2);
                 $pos=PopUp(["?","positive","negative"],1);
+                $ggb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/paqqv23d/width/438/height/474/border/888888/smb/false/stb/false/stbh/false/ai/false/asb/false/sri/true/rc/false/ld/false/sdz/false/ctl/false" width="438px" height="474px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
             </pg-code>
           <statement>
             <p>
-              [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/paqqv23d/width/438/height/474/border/888888/smb/false/stb/false/stbh/false/ai/false/asb/false/sri/true/rc/false/ld/false/sdz/false/ctl/false" width="438px" height="474px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+              <var name="$ggb" data="pgml"/>
             </p>
 
             <p>
@@ -230,9 +231,12 @@
 
     <exercise>
       <webwork>
+        <pg-code>
+          $ggb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/axzJ9c4S/width/438/height/474/border/888888/smb/false/stb/false/stbh/false/ai/false/asb/false/sri/true/rc/false/ld/false/sdz/false/ctl/false" width="438px" height="474px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
+        </pg-code>
           <statement>
             <p>
-              [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/axzJ9c4S/width/438/height/474/border/888888/smb/false/stb/false/stbh/false/ai/false/asb/false/sri/true/rc/false/ld/false/sdz/false/ctl/false" width="438px" height="474px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+              <var name="$ggb" data="pgml"/>
             </p>
 
             <p>
@@ -573,6 +577,7 @@
                     2, labels => ["g(x) = (x+3)^2 - sqrt(x)","g(x) = x^2 - sqrt(x+3)","g(x) = (x+3)^2 - (x+3)","g(x) = x^2 - sqrt(x) - 3","None of these"],
                     displayLabels => 0
                 );
+                $ggb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/VdWn6se7/width/431/height/313/border/888888/rc/false/ai/false/sdz/false/smb/false/stb/false/stbh/true/ld/false/sri/false/at/auto" width="431px" height="313px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
             </pg-code>
           <statement>
             <p>
@@ -582,7 +587,7 @@
             </p>
 
             <p>
-              [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/VdWn6se7/width/431/height/313/border/888888/rc/false/ai/false/sdz/false/smb/false/stb/false/stbh/true/ld/false/sri/false/at/auto" width="431px" height="313px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+              <var name="$ggb" data="pgml"/>
             </p>
 
             <p>
@@ -643,6 +648,7 @@
                     0, labels => ["g(x) = 5\left|x-2\right| - (x-2)^2 - 1","g(x) = 5\left|x-1\right| - (x-1)^2 - 2","g(x) = 5\left|x-2\right| - (x-2)^2","g(x) = 5\left|x-2\right| - (x-1)^2","None of these"],
                     displayLabels => 0
                 );
+                $ggb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/tunQVvGS/width/431/height/313/border/888888/rc/false/ai/false/sdz/false/smb/false/stb/false/stbh/true/ld/false/sri/false/at/auto" width="431px" height="313px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
             </pg-code>
           <statement>
             <p>
@@ -652,7 +658,7 @@
             </p>
 
             <p>
-              [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/tunQVvGS/width/431/height/313/border/888888/rc/false/ai/false/sdz/false/smb/false/stb/false/stbh/true/ld/false/sri/false/at/auto" width="431px" height="313px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+              <var name="$ggb" data="pgml"/>
             </p>
 
             <p>
@@ -717,9 +723,12 @@
 
     <exercise>
       <webwork>
+        <pg-code>
+          $ggb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/yK8kSe2P/width/431/height/469/border/888888/smb/false/stb/false/stbh/false/ai/false/asb/false/sri/true/rc/false/ld/false/sdz/false/ctl/false" width="431px" height="469px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
+        </pg-code>
           <statement>
             <p>
-              [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/yK8kSe2P/width/431/height/469/border/888888/smb/false/stb/false/stbh/false/ai/false/asb/false/sri/true/rc/false/ld/false/sdz/false/ctl/false" width="431px" height="469px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+              <var name="$ggb" data="pgml"/>
             </p>
 
             <p>
@@ -1388,6 +1397,9 @@
               $inOut=PopUp(
                 ["?","Input","Output"],"Input"
               );
+              $ggb = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/BmHTxqW6/width/421/height/260/border/888888/sri/true" width="421px" height="260px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
+              $ggb2 = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/kCE4de8p/width/421/height/260/border/888888/sri/true" width="421px" height="260px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
+              $ggb3 = q![@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/PNeV26dS/width/421/height/226/border/888888/sri/true" width="421px" height="260px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*!;
             </pg-code>
             <statement>
               <p>
@@ -1401,7 +1413,7 @@
               </p>
 
               <p>
-                [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/BmHTxqW6/width/421/height/260/border/888888/sri/true" width="421px" height="260px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+                <var name="$ggb" data="pgml"/>
               </p>
 
               <p>
@@ -1418,11 +1430,11 @@
                     </p>
 
                     <p>
-                      Graph 1 [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/kCE4de8p/width/421/height/260/border/888888/sri/true" width="421px" height="260px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+                      Graph 1 <var name="$ggb2" data="pgml"/>
                     </p>
 
                     <p>
-                      Graph 2 [@MODES(HTML=&gt;'&lt;iframe scrolling="no" src="https://www.geogebra.org/material/iframe/id/PNeV26dS/width/421/height/226/border/888888/sri/true" width="421px" height="260px" style="border:0px;"&gt; &lt;/iframe&gt;', TeX =&gt;"A GeoGebra applet.", PTX =&gt;"A GeoGebra applet.");@]*
+                      Graph 2 <var name="$ggb3" data="pgml"/>
                     </p>
 
                     <p>

--- a/src/frontmatter.xml
+++ b/src/frontmatter.xml
@@ -44,26 +44,26 @@
 
   <acknowledgement>
     <p>
-      Over several terms, Jack Green wrote most of the book's content as a Word/PDF document for use in his face-to-face and online Precalculus courses at <abbr>Mt.</abbr> Hood Community College.
+      Over several terms, Jack Green wrote most of the book's content as a Word/PDF document for use in his face-to-face and online Precalculus courses at Mt.<nbsp/>Hood Community College.
     </p>
 
     <p>
-      In 2016/2017, Nick Chura, Jack Green and <abbr>Dr.</abbr> Alex Jordan converted the material to PreTeXt (formerly MathBook XML),
+      In 2016/2017, Nick Chura, Jack Green and Dr.<nbsp/>Alex Jordan converted the material to PreTeXt (formerly MathBook XML),
       enabling the HTML output alongside a PDF,
       with support from an Open Oregon grant.
     </p>
 
     <p>
-      Special thanks to <abbr>Dr.</abbr> Rob Beezer, David Favreault, Jim Hatton, Robert Hauss,
-      <abbr>Dr.</abbr> Alex Jordan,
-      <abbr>Dr.</abbr> Elise Lockwood and Gina Shankland for proofreading and review.
+      Special thanks to Dr.<nbsp/>Rob Beezer, David Favreault, Jim Hatton, Robert Hauss,
+      Dr.<nbsp/>Alex Jordan,
+      Dr.<nbsp/>Elise Lockwood and Gina Shankland for proofreading and review.
     </p>
   </acknowledgement>
 
   <preface xml:id="to-all">
     <title>To All</title>
     <p>
-      Precalculus is taught at <abbr>Mt.</abbr> Hood Community College over two 10-week courses.
+      Precalculus is taught at Mt.<nbsp/>Hood Community College over two 10-week courses.
       This text aims to address all learning outcomes from the first course,
       suitable for use in a single 10-week term.
     </p>

--- a/src/projects-function-notation.xml
+++ b/src/projects-function-notation.xml
@@ -24,7 +24,7 @@
         <exercise>
         <statement>
           <p>
-            The graph in the figure models the amount of drug, <m>A(t)</m> <init>mg</init>, in a patient’s body after ingestion as a function of time, <m>t</m> hours.  The body absorbs the drug at a linear rate, but then eliminates the drug at an exponential rate
+            The graph in the figure models the amount of drug, <m>A(t)</m> mg, in a patient’s body after ingestion as a function of time, <m>t</m> hours.  The body absorbs the drug at a linear rate, but then eliminates the drug at an exponential rate
           </p>
           <p>
             <ol label="a">
@@ -1163,22 +1163,22 @@
             As the temperature drops, so does the speed of sound. The function
             <me>v=f(T)=740.4+1.34T</me> models the speed of sound (in miles per
             hour) when the temperature is <m>T</m> degrees Celsius. On a
-            particular day between <m>6:00</m> <init>p.m.</init> and midnight,
+            particular day between <m>6:00</m> <pm/> and midnight,
             suppose the temperature outside is modeled by the function
             <me>=g(h)=24-3h</me> where <m>h</m> is the number of hours after
-            <m>6{:}00</m> <init>p.m.</init>
+            <m>6{:}00</m> <pm/>.
           </p>
           <p>
             <ol label="a">
               <li>
                 <p>
-                  Determine the speed of sound at <m>9</m> <init>p.m.</init>.
+                  Determine the speed of sound at <m>9</m> <pm/>.
                 </p>
               </li>
               <li>
                 <p>
                   Determine a formula for the function that will find the speed
-                  of sound, <m>h</m> hours after <m>6{:}00</m> <init>p.m.</init>.
+                  of sound, <m>h</m> hours after <m>6{:}00</m> <pm/>.
                 </p>
               </li>
             </ol>
@@ -1332,21 +1332,21 @@
         <exercise>
         <statement>
           <p>
-            A doctor disconnects the intravenous flow of a drug into a patient’s body at <m>10</m> <init>a.m.</init>  At noon she measures the amount of drug in the patient’s body to be <m>180</m> <init>mg</init>. At <m>5</m> <init>p.m.</init> she measures <m>35</m> <init>mg</init> of drug in the patient’s body.
+            A doctor disconnects the intravenous flow of a drug into a patient’s body at <m>10</m> <am/>  At noon she measures the amount of drug in the patient’s body to be <m>180</m> mg. At <m>5</m> <pm/> she measures <m>35</m> mg of drug in the patient’s body.
           </p>
           <p>
             <ol label="a">
               <li>
-                <p>Find a linear formula, <m>L(t)</m>, that models the amount of drug, in <init>mg</init>,  in the patient’s body as a function of time, <m>t</m> hours after <m>10</m> <init>a.m.</init>
+                <p>Find a linear formula, <m>L(t)</m>, that models the amount of drug, in mg,  in the patient’s body as a function of time, <m>t</m> hours after <m>10</m> <am/>.
                 </p>
               </li>
               <li>
-                <p>Find an exponential formula, <m>E(t)</m>,  that models the amount of drug, <init>mg</init>, in the patient’s body as a function of time, <m>t</m> hours after <m>10</m> <init>a.m.</init>
+                <p>Find an exponential formula, <m>E(t)</m>,  that models the amount of drug, mg, in the patient’s body as a function of time, <m>t</m> hours after <m>10</m> <am/>.
                 </p>
               </li>
               <li>
                 <p>
-                  Sketch a graph of each equation <m>L(t)</m> and <m>E(t)</m> on the same set of axes. Limit the domain between <m>0</m> and <m>12</m> hours after <m>10</m> <init>a.m.</init>. Use a ruler to draw the axes and label your axes including units.
+                  Sketch a graph of each equation <m>L(t)</m> and <m>E(t)</m> on the same set of axes. Limit the domain between <m>0</m> and <m>12</m> hours after <m>10</m> <am/>. Use a ruler to draw the axes and label your axes including units.
                   (One picture, two graphs in the same picture)
                 </p>
               </li>


### PR DESCRIPTION
This includes a commit that moves all of the GGB calls up to inside the pg-code. This protects the characters that otherwise would get escaped.

Previously, I showed you a line or two to modify in mathbook that had the same final effect. But now that edit is not needed and your mathbook repo can go back to being unadulterated.